### PR TITLE
Fixing asserts not being removed

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-var gulp = require('gulp');
-var gjslint = require('gulp-gjslint');
-var sourcemaps = require('gulp-sourcemaps');
+var assign = require('lodash').assign;
+var browserify = require('browserify');
+var buffer = require('vinyl-buffer');
 var del = require('del');
+var gjslint = require('gulp-gjslint');
+var gulp = require('gulp');
+var gutil = require('gulp-util');
 var karma = require('karma').server;
 var path = require('path');
-var browserify = require('browserify');
 var source = require('vinyl-source-stream');
-var buffer = require('vinyl-buffer');
+var sourcemaps = require('gulp-sourcemaps');
+var uglify = require('gulp-uglify');
 var watchify = require('watchify');
-var gutil = require('gulp-util');
-var assign = require('lodash').assign;
 
 var jsFileName = 'incremental-dom.js';
 var srcs = [jsFileName, 'src/**/*.js'];
@@ -63,7 +64,8 @@ gulp.task('lint', function() {
 var customOpts = {
   entries: './index.js',
   standalone: 'IncrementalDOM',
-  debug: true
+  debug: true,
+  transform: [ 'envify' ]
 };
 var opts = assign({}, watchify.args, customOpts);
 var b_watch = watchify(browserify(opts));
@@ -78,6 +80,8 @@ function bundle(browserify) {
     .pipe(source(jsFileName))
     .pipe(buffer())
     .pipe(sourcemaps.init({loadMaps: true}))
+      .pipe(uglify())
+      .on('error', gutil.log)
     .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest('dist'));
 }

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
   "devDependencies": {
     "browserify": "~9.0.8",
     "del": "~1.1.1",
+    "envify": "~3.4.0",
     "es6ify": "~1.6.0",
     "gulp": "~3.8.11",
-    "gulp-jshint": "~1.10.0",
+    "gulp-gjslint": "~0.1.4",
     "gulp-sourcemaps": "~1.5.1",
+    "gulp-uglify": "~1.2.0",
     "gulp-util": "~3.0.4",
     "karma": "~0.12.31",
     "karma-browserify": "~4.1.2",
@@ -24,7 +26,6 @@
     "sinon-chai": "~2.7.0",
     "vinyl-buffer": "~1.0.0",
     "vinyl-source-stream": "~1.1.0",
-    "watchify": "~3.1.1",
-    "gulp-gjslint": "~0.1.4"
+    "watchify": "~3.1.1"
   }
 }

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -41,49 +41,45 @@ var ATTRIBUTES_OFFSET = 3;
 var argsBuilder = [];
 
 
-if (process.env.node_env === 'production') {
+if (process.env.NODE_ENV !== 'production') {
   /**
    * Keeps track whether or not we are in an attributes declaration (after
    * ie_open_start, but before ie_open_end).
    * @type {boolean}
    */
   var inAttributes = false;
-}
 
 
-/** Makes sure that the caller is not where attributes are expected. */
-var assertNotInAttributes = function() {
-  if (process.env.node_env === 'production' && inAttributes) {
-    throw new Error('Was not expecting a call to iattr or ie_open_end, ' +
-        'they must follow a call to ie_open_start.');
-  }
-};
+  /** Makes sure that the caller is not where attributes are expected. */
+  var assertNotInAttributes = function() {
+    if (inAttributes) {
+      throw new Error('Was not expecting a call to iattr or ie_open_end, ' +
+          'they must follow a call to ie_open_start.');
+    }
+  };
 
 
-/** Makes sure that the caller is where attributes are expected. */
-var assertInAttributes = function() {
-  if (process.env.node_env === 'production' && !inAttributes) {
-    throw new Error('Was expecting a call to iattr or ie_open_end. ' +
-        'ie_open_start must be followed by zero or more calls to iattr, ' +
-        'then one call to ie_open_end.');
-  }
-};
+  /** Makes sure that the caller is where attributes are expected. */
+  var assertInAttributes = function() {
+    if (!inAttributes) {
+      throw new Error('Was expecting a call to iattr or ie_open_end. ' +
+          'ie_open_start must be followed by zero or more calls to iattr, ' +
+          'then one call to ie_open_end.');
+    }
+  };
 
 
-/** Updates the state to being in an attribute declaration. */
-var setInAttributes = function() {
-  if (process.env.node_env === 'production') {
+  /** Updates the state to being in an attribute declaration. */
+  var setInAttributes = function() {
     inAttributes = true;
-  }
-};
+  };
 
 
-/** Updates the state to not being in an attribute declaration. */
-var setNotInAttributes = function() {
-  if (process.env.node_env === 'production') {
+  /** Updates the state to not being in an attribute declaration. */
+  var setNotInAttributes = function() {
     inAttributes = false;
-  }
-};
+  };
+}
 
 
 /**
@@ -187,7 +183,9 @@ var updateAttributes = function(node, newAttrs) {
  *     for the Element.
  */
 var ie_open = function(tag, key, statics, var_args) {
-  assertNotInAttributes();
+  if (process.env.NODE_ENV !== 'production') {
+    assertNotInAttributes();
+  }
 
   var node = alignWithDOM(tag, key, statics);
 
@@ -215,8 +213,10 @@ var ie_open = function(tag, key, statics, var_args) {
  *     Element is created.
  */
 var ie_open_start = function(tag, key, statics) {
-  assertNotInAttributes();
-  setInAttributes();
+  if (process.env.NODE_ENV !== 'production') {
+    assertNotInAttributes();
+    setInAttributes();
+  }
 
   argsBuilder[0] = tag;
   argsBuilder[1] = key;
@@ -233,7 +233,9 @@ var ie_open_start = function(tag, key, statics) {
  * @param {*} value
  */
 var iattr = function(name, value) {
-  assertInAttributes();
+  if (process.env.NODE_ENV !== 'production') {
+    assertInAttributes();
+  }
 
   argsBuilder.push(name, value);
 };
@@ -243,8 +245,10 @@ var iattr = function(name, value) {
  * Closes an open tag started with ie_open_start.
  */
 var ie_open_end = function() {
-  assertInAttributes();
-  setNotInAttributes();
+  if (process.env.NODE_ENV !== 'production') {
+    assertInAttributes();
+    setNotInAttributes();
+  }
 
   ie_open.apply(null, argsBuilder);
 };
@@ -256,7 +260,9 @@ var ie_open_end = function() {
  * @param {string} tag The element's tag.
  */
 var ie_close = function(tag) {
-  assertNotInAttributes();
+  if (process.env.NODE_ENV !== 'production') {
+    assertNotInAttributes();
+  }
 
   parentNode();
   nextSibling();
@@ -277,7 +283,9 @@ var ie_close = function(tag) {
  *     for the Element.
  */
 var ie_void = function(tag, key, statics, var_args) {
-  assertNotInAttributes();
+  if (process.env.NODE_ENV !== 'production') {
+    assertNotInAttributes();
+  }
 
   ie_open.apply(null, arguments);
   ie_close.apply(null, arguments);
@@ -290,7 +298,9 @@ var ie_void = function(tag, key, statics, var_args) {
  * @param {string} value The text of the Text.
  */
 var itext = function(value) {
-  assertNotInAttributes();
+  if (process.env.NODE_ENV !== 'production') {
+    assertNotInAttributes();
+  }
 
   var node = alignWithDOM('#text', null, value);
   var data = getData(node);


### PR DESCRIPTION
Changing asserts from being active in production to not being active in production
Adding envify to replace process.env.NODE_ENV
Moving checking of NODE_ENV to where assert functions are called as uglify cannot remove functions with no side effects
Adding uglify to strip out dead code
Sorting requires in gulpfile

@cramforce
