### PR TITLE
Migrate to TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 dist/
+src/**/*.js
+test/**/*.js

--- a/src/alignment.ts
+++ b/src/alignment.ts
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-var nodes = require('./nodes'),
-    createNode = nodes.createNode,
-    getKey = nodes.getKey,
-    getNodeName = nodes.getNodeName,
-    getChild = nodes.getChild,
-    registerChild = nodes.registerChild;
-var markVisited = require('./traversal').markVisited;
-var getWalker = require('./walker').getWalker;
+import nodes = require('./nodes');
+var {createNode, getKey, getNodeName, getChild, registerChild} = nodes;
+import {markVisited} from './traversal';
+import {getWalker} from './walker';
 
 
 /**
@@ -50,7 +46,7 @@ var matches = function(node, nodeName, key) {
  *     node.
  * @return {!Node} The matching node.
  */
-var alignWithDOM = function(nodeName, key, statics) {
+export var alignWithDOM = function(nodeName, key, statics) {
   var walker = getWalker();
   var currentNode = walker.currentNode;
   var parent = walker.getCurrentParent();
@@ -78,11 +74,5 @@ var alignWithDOM = function(nodeName, key, statics) {
   markVisited(parent, matchingNode);
 
   return matchingNode;
-};
-
-
-/** */
-module.exports = {
-  alignWithDOM: alignWithDOM
 };
 

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-var getData = require('./node_data').getData;
+import {getData} from './node_data';
 
 
 /**
@@ -77,7 +77,7 @@ var applyStyle = function(el, style) {
  * @param {*} value The attribute's value. If the value is a string, it is set
  *     as an HTML attribute, otherwise, it is set on node.
  */
-var updateAttribute = function(el, name, value) {
+export var updateAttribute = function(el, name, value) {
   switch (name) {
     case 'id':
       el.id = value;
@@ -96,10 +96,3 @@ var updateAttribute = function(el, name, value) {
       break;
   }
 };
-
-
-/** */
-module.exports = {
-  updateAttribute: updateAttribute
-};
-

--- a/src/node_data.ts
+++ b/src/node_data.ts
@@ -82,7 +82,7 @@ function NodeData(nodeName, key) {
  * @param {?string} key The key that identifies the node.
  * @return {!NodeData} The newly initialized data object
  */
-var initData = function(node, nodeName, key) {
+export var initData = function(node, nodeName, key) {
   var data = new NodeData(nodeName, key);
   node['__incrementalDOMData'] = data;
   return data;
@@ -95,7 +95,7 @@ var initData = function(node, nodeName, key) {
  * @param {!Node} node The node to retrieve the data for.
  * @return {NodeData} The NodeData for this Node.
  */
-var getData = function(node) {
+export var getData = function(node) {
   var data = node['__incrementalDOMData'];
 
   if (!data) {
@@ -111,11 +111,3 @@ var getData = function(node) {
 
   return data;
 };
-
-
-/** */
-module.exports = {
-  getData: getData,
-  initData: initData
-};
-

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-var updateAttribute = require('./attributes').updateAttribute;
-var nodeData = require('./node_data'),
-    getData = nodeData.getData,
-    initData = nodeData.initData;
-
+import {updateAttribute} from './attributes';
+import * as nodeData from './node_data';
+var {getData, initData } = nodeData;
 
 /**
  * Creates an Element.
@@ -69,7 +67,7 @@ var createTextNode = function(doc, text) {
  *     intial content of the Text.
  * @return {!Node}
  */
-var createNode = function(doc, nodeName, key, statics) {
+export var createNode = function(doc, nodeName, key, statics) {
   if (nodeName === '#text') {
     return createTextNode(doc, statics);
   }
@@ -106,7 +104,7 @@ var createKeyMap = function(el) {
  * @param {?Node} node A node to get the key for.
  * @return {?string} The key for the Node, if applicable.
  */
-var getKey = function(node) {
+export var getKey = function(node) {
   return getData(node).key;
 };
 
@@ -115,7 +113,7 @@ var getKey = function(node) {
  * @param {?Node} node A node to get the node name for.
  * @return {?string} The node name for the Node, if applicable.
  */
-var getNodeName = function(node) {
+export var getNodeName = function(node) {
   return getData(node).nodeName;
 };
 
@@ -143,7 +141,7 @@ var getKeyMap = function(el) {
  * @param {?string} key
  * @return {?Node} The child corresponding to the key.
  */
-var getChild = function(parent, key) {
+export var getChild = function(parent, key) {
   return getKeyMap(parent)[key];
 };
 
@@ -157,19 +155,8 @@ var getChild = function(parent, key) {
  * @param {?string} key A key to identify the child with.
  * @param {!Node} child The child to register.
  */
-var registerChild = function(parent, key, child) {
+export var registerChild = function(parent, key, child) {
   if (key) {
     getKeyMap(parent)[key] = child;
   }
 };
-
-
-/** */
-module.exports = {
-  createNode: createNode,
-  getKey: getKey,
-  getNodeName: getNodeName,
-  getChild: getChild,
-  registerChild: registerChild
-};
-

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-var traversal = require('./traversal'),
-    firstChild = traversal.firstChild,
-    parentNode = traversal.parentNode;
-var TreeWalker = require('./tree_walker');
-var walker = require('./walker'),
-    getWalker = walker.getWalker,
-    setWalker = walker.setWalker;
+import * as traversal from './traversal';
+var {firstChild,parentNode} = traversal;
+import TreeWalker = require('./tree_walker');
+import * as walker from './walker';
+var {getWalker, setWalker} = walker;
 
 
 /**
@@ -30,7 +28,7 @@ var walker = require('./walker'),
  * @param {!function} fn A function containing elementOpen/elementClose/etc.
  *     calls that describe the DOM.
  */
-var patch = function(el, fn) {
+export var patch = function(el, fn) {
   var prevWalker = getWalker();
   setWalker(new TreeWalker(el));
 
@@ -39,11 +37,5 @@ var patch = function(el, fn) {
   parentNode();
 
   setWalker(prevWalker);
-};
-
-
-/** */
-module.exports = {
-  patch: patch
 };
 

--- a/src/traversal.ts
+++ b/src/traversal.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-var getWalker = require('./walker').getWalker;
-var getData = require('./node_data').getData;
+import {getWalker} from './walker';
+import {getData} from './node_data';
 
 
 /**
@@ -56,7 +56,7 @@ var exitNode = function(node) {
  * @param {!Element} parent
  * @param {!Node} child
  */
-var markVisited = function(parent, child) {
+export var markVisited = function(parent, child) {
   var data = getData(parent);
   data.lastVisitedChild = child;
 };
@@ -65,7 +65,7 @@ var markVisited = function(parent, child) {
 /**
  * Changes to the first child of the current node.
  */
-var firstChild = function() {
+export var firstChild = function() {
   var walker = getWalker();
   enterNode(walker.currentNode);
   walker.firstChild();
@@ -75,7 +75,7 @@ var firstChild = function() {
 /**
  * Changes to the next sibling of the current node.
  */
-var nextSibling = function() {
+export var nextSibling = function() {
   var walker = getWalker();
   walker.nextSibling();
 };
@@ -84,18 +84,8 @@ var nextSibling = function() {
 /**
  * Changes to the parent of the current node, removing any unvisited children.
  */
-var parentNode = function() {
+export var parentNode = function() {
   var walker = getWalker();
   walker.parentNode();
   exitNode(walker.currentNode);
 };
-
-
-/** */
-module.exports = {
-  firstChild: firstChild,
-  nextSibling: nextSibling,
-  parentNode: parentNode,
-  markVisited: markVisited
-};
-

--- a/src/tree_walker.ts
+++ b/src/tree_walker.ts
@@ -72,5 +72,5 @@ TreeWalker.prototype.parentNode = function() {
 
 
 /** */
-module.exports = TreeWalker;
+export = TreeWalker;
 

--- a/src/virtual_elements.ts
+++ b/src/virtual_elements.ts
@@ -256,10 +256,8 @@ export var elementOpenEnd = function() {
 
 /**
  * Closes an open virtual Element.
- *
- * @param {string} tag The element's tag.
  */
-export var elementClose = function(tag) {
+export var elementClose = function() {
   if (process.env.NODE_ENV !== 'production') {
     assertNotInAttributes();
   }

--- a/src/virtual_elements.ts
+++ b/src/virtual_elements.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-var alignWithDOM = require('./alignment').alignWithDOM;
-var updateAttribute = require('./attributes').updateAttribute;
-var getData = require('./node_data').getData;
-var getWalker = require('./walker').getWalker;
-var traversal = require('./traversal'),
-    firstChild = traversal.firstChild,
-    nextSibling = traversal.nextSibling,
-    parentNode = traversal.parentNode;
+declare var process;
+
+import {alignWithDOM} from './alignment';
+import {updateAttribute} from './attributes';
+import {getData} from './node_data';
+import {getWalker} from './walker';
+import traversal = require('./traversal');
+var {firstChild, nextSibling, parentNode} = traversal;
 
 
 /**
@@ -182,7 +182,7 @@ var updateAttributes = function(node, newAttrs) {
  * @param {...*} var_args Attribute name/value pairs of the dynamic attributes
  *     for the Element.
  */
-var elementOpen = function(tag, key, statics, var_args) {
+export var elementOpen = function(tag, key?, statics?, ...var_args) {
   if (process.env.NODE_ENV !== 'production') {
     assertNotInAttributes();
   }
@@ -212,7 +212,7 @@ var elementOpen = function(tag, key, statics, var_args) {
  *     static attributes for the Element. These will only be set once when the
  *     Element is created.
  */
-var elementOpenStart = function(tag, key, statics) {
+export var elementOpenStart = function(tag, key, statics) {
   if (process.env.NODE_ENV !== 'production') {
     assertNotInAttributes();
     setInAttributes();
@@ -232,7 +232,7 @@ var elementOpenStart = function(tag, key, statics) {
  * @param {string} name
  * @param {*} value
  */
-var attr = function(name, value) {
+export var attr = function(name, value) {
   if (process.env.NODE_ENV !== 'production') {
     assertInAttributes();
   }
@@ -244,7 +244,7 @@ var attr = function(name, value) {
 /**
  * Closes an open tag started with elementOpenStart.
  */
-var elementOpenEnd = function() {
+export var elementOpenEnd = function() {
   if (process.env.NODE_ENV !== 'production') {
     assertInAttributes();
     setNotInAttributes();
@@ -259,7 +259,7 @@ var elementOpenEnd = function() {
  *
  * @param {string} tag The element's tag.
  */
-var elementClose = function(tag) {
+export var elementClose = function(tag) {
   if (process.env.NODE_ENV !== 'production') {
     assertNotInAttributes();
   }
@@ -282,7 +282,7 @@ var elementClose = function(tag) {
  * @param {...*} var_args Attribute name/value pairs of the dynamic attributes
  *     for the Element.
  */
-var elementVoid = function(tag, key, statics, var_args) {
+export var elementVoid = function(tag, key, statics?, ...var_args) {
   if (process.env.NODE_ENV !== 'production') {
     assertNotInAttributes();
   }
@@ -297,7 +297,7 @@ var elementVoid = function(tag, key, statics, var_args) {
  *
  * @param {string} value The text of the Text.
  */
-var text = function(value) {
+export var text = function(value) {
   if (process.env.NODE_ENV !== 'production') {
     assertNotInAttributes();
   }
@@ -311,17 +311,5 @@ var text = function(value) {
   }
 
   nextSibling();
-};
-
-
-/** */
-module.exports = {
-  elementOpenStart: elementOpenStart,
-  elementOpenEnd: elementOpenEnd,
-  elementOpen: elementOpen,
-  elementVoid: elementVoid,
-  elementClose: elementClose,
-  text: text,
-  attr: attr
 };
 

--- a/src/walker.ts
+++ b/src/walker.ts
@@ -23,7 +23,7 @@ var walker_;
 /**
  * @return {TreeWalker} the current TreeWalker
  */
-var getWalker = function() {
+export var getWalker = function() {
   return walker_;
 };
 
@@ -32,14 +32,6 @@ var getWalker = function() {
  * Sets the current TreeWalker
  * @param {TreeWalker} walker
  */
-var setWalker = function(walker) {
+export var setWalker = function(walker) {
   walker_ = walker;
 };
-
-
-/** */
-module.exports = {
-  getWalker: getWalker,
-  setWalker: setWalker
-};
-

--- a/test/functional/attributes.ts
+++ b/test/functional/attributes.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    elementVoid = IncrementalDOM.elementVoid;
+import {patch} from '../../src/patch';
+import {elementVoid} from '../../src/virtual_elements';
 
 describe('attribute updates', () => {
   var container;

--- a/test/functional/conditional_rendering.ts
+++ b/test/functional/conditional_rendering.ts
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    elementOpen = IncrementalDOM.elementOpen,
-    elementClose = IncrementalDOM.elementClose,
-    elementVoid = IncrementalDOM.elementVoid;
+import {patch} from "../../src/patch";
+import {elementOpen, elementClose, elementVoid} from "../../src/virtual_elements";
 
 describe('conditional rendering', () => {
   var container;

--- a/test/functional/element_creation.ts
+++ b/test/functional/element_creation.ts
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    elementOpen = IncrementalDOM.elementOpen,
-    elementClose = IncrementalDOM.elementClose,
-    elementVoid = IncrementalDOM.elementVoid;
+import {patch} from "../../src/patch";
+import {elementOpen, elementClose, elementVoid} from "../../src/virtual_elements";
 
 describe('element creation', () => {
   var container;

--- a/test/functional/keyed_items.ts
+++ b/test/functional/keyed_items.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    elementVoid = IncrementalDOM.elementVoid;
+import {patch} from "../../src/patch";
+import {elementVoid} from "../../src/virtual_elements";
 
 describe('rendering with keys', () => {
   var container;

--- a/test/functional/patch.ts
+++ b/test/functional/patch.ts
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    elementOpen = IncrementalDOM.elementOpen,
-    elementClose = IncrementalDOM.elementClose,
-    elementVoid = IncrementalDOM.elementVoid,
-    text = IncrementalDOM.text;
+import {patch} from "../../src/patch";
+import {elementOpen, elementClose, elementVoid, text} from "../../src/virtual_elements";
 
 describe('patching an element', () => {
   var container;
@@ -94,6 +90,6 @@ describe('patching a documentFragment', function() {
       elementClose('div');
     });
 
-    expect(frag.children[0].id).to.equal('aDiv');
+    expect(frag.childNodes[0]['id']).to.equal('aDiv');
   });
 });

--- a/test/functional/patch.ts
+++ b/test/functional/patch.ts
@@ -66,7 +66,7 @@ describe('patching an element', () => {
       elementOpen('div');
         patch(containerTwo, renderTwo);
         text('hello');
-      elementClose('div');
+      elementClose();
     }
 
     function renderTwo() {
@@ -87,7 +87,7 @@ describe('patching a documentFragment', function() {
     patch(frag, function() {
       elementOpen('div', null, null,
           'id', 'aDiv');
-      elementClose('div');
+      elementClose();
     });
 
     expect(frag.childNodes[0]['id']).to.equal('aDiv');

--- a/test/functional/text_nodes.ts
+++ b/test/functional/text_nodes.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    text = IncrementalDOM.text;
+import {patch} from "../../src/patch";
+import {text} from "../../src/virtual_elements";
 
 describe('text nodes', () => {
   var container;

--- a/test/functional/virtual_attributes.ts
+++ b/test/functional/virtual_attributes.ts
@@ -36,7 +36,7 @@ describe('virtual attribute updates', () => {
           attr('data-expanded', obj.key);
         }
       elementOpenEnd();
-      elementClose('div');
+      elementClose();
     }
 
     it('should be present when specified', () => {

--- a/test/functional/virtual_attributes.ts
+++ b/test/functional/virtual_attributes.ts
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    elementOpenStart = IncrementalDOM.elementOpenStart,
-    elementOpenEnd = IncrementalDOM.elementOpenEnd,
-    elementClose = IncrementalDOM.elementClose,
-    attr = IncrementalDOM.attr;
+import {patch} from "../../src/patch";
+import {elementOpenStart, elementOpenEnd, elementClose, attr} from "../../src/virtual_elements";
 
 describe('virtual attribute updates', () => {
   var container;

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -1,0 +1,5 @@
+declare var describe
+,it
+,expect
+,beforeEach
+,afterEach;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,40 @@
+{
+    "version": "1.5.0-beta",
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "isolatedModules": false,
+        "jsx": "react",
+        "experimentalDecorators": true,
+        "emitDecoratorMetadata": true,
+        "declaration": false,
+        "noImplicitAny": false,
+        "removeComments": false,
+        "noLib": false,
+        "preserveConstEnums": true,
+        "suppressImplicitAnyIndexErrors": true
+    },
+    "filesGlob": [
+        "./src/**/*.ts",
+        "./test/**/*.ts"
+    ],
+    "files": [
+        "./src/alignment.ts",
+        "./src/attributes.ts",
+        "./src/node_data.ts",
+        "./src/nodes.ts",
+        "./src/patch.ts",
+        "./src/traversal.ts",
+        "./src/tree_walker.ts",
+        "./src/virtual_elements.ts",
+        "./src/walker.ts",
+        "./test/functional/attributes.ts",
+        "./test/functional/conditional_rendering.ts",
+        "./test/functional/element_creation.ts",
+        "./test/functional/keyed_items.ts",
+        "./test/functional/patch.ts",
+        "./test/functional/text_nodes.ts",
+        "./test/functional/virtual_attributes.ts",
+        "./test/test.d.ts"
+    ]
+}


### PR DESCRIPTION
Two commits: 
- First commit simply:
  * Add a `tsconfig.json` TypeScript project file.
  * renames the `.js` files to `.ts`
  * Using the es6 module syntax where allowed
  * declares globals used in the project, tests
- Second commit: 
  * Fixes something identified because of this migration  

There will be more housekeeping needed for this to be usable by *everyone* 

* I'm using https://atom.io/packages/atom-typescript to manage my compilation will setup a gulp task for everyone.
* Will TSify more things, move to `classes` and such. 
* Will setup a documentation generation using TypeDoc (see example http://facebook.github.io/immutable-js/docs/)

The purpose of opening this PR is to gauge interest in this migration given it has already shown *some benefit*. 