### PR TITLE
Don't reset iteration on changed attr

### DIFF
--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -117,10 +117,8 @@ var hasChangedAttrs = function(unused1, unused2, unused3, var_args) {
     }
   }
 
-  if (attrsChanged) {
-    for (i = ATTRIBUTES_OFFSET; i < arguments.length; i += 2) {
-      attrsArr[(i - ATTRIBUTES_OFFSET) >> 1] = arguments[i + 1];
-    }
+  for (; i < arguments.length; i += 2) {
+    attrsArr[(i - ATTRIBUTES_OFFSET) >> 1] = arguments[i + 1];
   }
 
   return attrsChanged;


### PR DESCRIPTION
Since we've [already determined](https://github.com/google/incremental-dom/blob/7e8590053a20d167202a9b2cd79e7984301c96dc/src/virtual_elements.js#L110-L118) that everything preceding this attribute hasn't changed, there's no reason to reset and update them all.