### PR TITLE
Require lodash.assign

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-var assign = require('lodash').assign;
+var assign = require('lodash.assign');
 var browserify = require('browserify');
 var buffer = require('vinyl-buffer');
 var del = require('del');

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "karma-firefox-launcher": "~0.1.4",
     "karma-mocha": "^0.2.0",
     "karma-sinon-chai": "^1.0.0",
-    "lodash": "^3.10.0",
+    "lodash.assign": "^3.2.0",
     "mocha": "^2.2.5",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0",


### PR DESCRIPTION
Instead of including all of lodash just to use `assign`, we can use the `lodash.assign` npm module.