### PR TITLE
Add npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
     "type": "git",
     "url": "https://github.com/google/incremental-dom.git"
   },
+  "scripts": {
+    "test": "gulp unit",
+    "lint": "gulp lint",
+    "build": "gulp build",
+    "dist": "gulp dist"
+  },
   "devDependencies": {
     "browserify": "^10.2.4",
     "chai": "^3.0.0",


### PR DESCRIPTION
Especially useful for running tests (I struggled with running tests when first contributing).

Adds:
- `$ npm test`
- `$ npm run lint`
- `$ npm run build`
- `$ npm run dist`

Since `$ npm test` wasn’t defined, and there was a gulpfile, I then tried `$ gulp test`. That didn’t work, so I had to open and scan to figure out it’s `$ gulp unit`. Not the best experience for new contributors.