### PR TITLE
Removing special case setting of class using className as it doesn't …

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -82,9 +82,6 @@ var updateAttribute = function(el, name, value) {
     case 'id':
       el.id = value;
       break;
-    case 'class':
-      el.className = value;
-      break;
     case 'tabindex':
       el.tabIndex = value;
       break;

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -182,5 +182,19 @@ describe('attribute updates', () => {
       expect(el.style.backgroundColor).to.equal('red');
     });
   });
+
+  describe('for svg elements', () => {
+    it('should correctly apply the class attribute', function() {
+      patch(container, () => {
+        elementVoid('svg', null, null,
+            'class', 'foo');
+      });
+      var el = container.childNodes[0];
+
+      expect(el.getAttribute('class')).to.equal('foo');
+    });
+
+
+  });
 });
 


### PR DESCRIPTION
…work for SVG elements.

Fixes #29
@cramforce 