### PR TITLE
Remove prop setter shorthands

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -9,7 +9,7 @@ https://developers.google.com/open-source/cla/individual
 https://developers.google.com/open-source/cla/corporate
 
 If you or your organization is not listed there already, you should
-add an entry to the AUTHORS file as part of your patch.
+add an entry to the CONTRIBUTORS file as part of your patch.
 
 If you plan to add a significant component or large chunk of code, it
 is recommended to bring it up on the discussion list for a design

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,3 +2,4 @@
 #     Name <email address>
 
 Sepand Parhami <sparhami@google.com>
+Justin Ridgewell <justin@ridgewell.name>

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -78,19 +78,10 @@ var applyStyle = function(el, style) {
  *     as an HTML attribute, otherwise, it is set on node.
  */
 var updateAttribute = function(el, name, value) {
-  switch (name) {
-    case 'id':
-      el.id = value;
-      break;
-    case 'tabindex':
-      el.tabIndex = value;
-      break;
-    case 'style':
-      applyStyle(el, value);
-      break;
-    default:
-      applyAttr(el, name, value);
-      break;
+  if (name === 'style') {
+    applyStyle(el, value);
+  } else {
+    applyAttr(el, name, value);
   }
 };
 

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -16,6 +16,10 @@
 
 var IncrementalDOM = require('../../index'),
     patch = IncrementalDOM.patch,
+    elementOpenStart = IncrementalDOM.elementOpenStart,
+    elementOpenEnd = IncrementalDOM.elementOpenEnd,
+    elementAttr = IncrementalDOM.attr,
+    elementClose = IncrementalDOM.elementClose,
     elementVoid = IncrementalDOM.elementVoid;
 
 describe('attribute updates', () => {
@@ -31,14 +35,18 @@ describe('attribute updates', () => {
   });
 
   describe('for conditional attributes', () => {
-    function render(obj) {
-      elementVoid('div', '', [],
-          'data-expanded', obj.key);
+    function render(attrs) {
+      elementOpenStart('div', '', []);
+      for (var attr in attrs) {
+          elementAttr(attr, attrs[attr]);
+      }
+      elementOpenEnd();
+      elementClose('div');
     }
 
     it('should be present when they have a value', () => {
       patch(container, () => render({
-        key: 'hello'
+        'data-expanded': 'hello'
       }));
       var el = container.childNodes[0];
 
@@ -47,7 +55,7 @@ describe('attribute updates', () => {
 
     it('should be present when falsy', () => {
       patch(container, () => render({
-        key: false
+        'data-expanded': false
       }));
       var el = container.childNodes[0];
 
@@ -56,19 +64,23 @@ describe('attribute updates', () => {
 
     it('should be not present when undefined', () => {
       patch(container, () => render({
-        key: undefined
+        id: undefined,
+        tabindex: undefined,
+        'data-expanded': undefined
       }));
       var el = container.childNodes[0];
 
       expect(el.getAttribute('data-expanded')).to.equal(null);
+      expect(el.getAttribute('id')).to.equal(null);
+      expect(el.getAttribute('tabindex')).to.equal(null);
     });
 
     it('should update the DOM when they change', () => {
       patch(container, () => render({
-        key: 'foo'
+        'data-expanded': 'foo'
       }));
       patch(container, () => render({
-        key: 'bar'
+        'data-expanded': 'bar'
       }));
       var el = container.childNodes[0];
 


### PR DESCRIPTION
They were interfering with removing the props.

```js
var container = document.createElement('div');

patch(container, function() {
    elementOpen('div', null, null, 'id', 'test');
});
patch(container, function() {
    elementOpen('div', null, null, 'id', undefined);
});

var el = container.firstChild;
el.id; // => "undefined"
el.getAttribute('id'); // => "undefined"
```
If we always use `applyAttr`, any attribute can be unset.