### PR TITLE
Avoid unnecessary registerChild call

### DIFF
--- a/src/alignment.js
+++ b/src/alignment.js
@@ -68,7 +68,9 @@ var alignWithDOM = function(nodeName, key, statics) {
       matchingNode = existingNode;
     } else {
       matchingNode = createNode(walker.doc, nodeName, key, statics);
-      registerChild(parent, key, matchingNode);
+      if (key) {
+        registerChild(parent, key, matchingNode);
+      }
     }
 
     parent.insertBefore(matchingNode, currentNode);

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -158,18 +158,15 @@ var getChild = function(parent, key) {
 
 
 /**
- * Registers a node as being a child. If a key is provided, the parent will
- * keep track of the child using the key. The child can be retrieved using the
- * same key using getKeyMap. The provided key should be unique within the
- * parent Element.
+ * Registers a node as being a child. The parent will keep track of the child
+ * using the key. The child can be retrieved using the same key using
+ * getKeyMap. The provided key should be unique within the parent Element.
  * @param {!Element} parent The parent of child.
- * @param {?string} key A key to identify the child with.
+ * @param {string} key A key to identify the child with.
  * @param {!Node} child The child to register.
  */
 var registerChild = function(parent, key, child) {
-  if (key) {
-    getKeyMap(parent)[key] = child;
-  }
+  getKeyMap(parent)[key] = child;
 };
 
 


### PR DESCRIPTION
If we guard `registerChild` like we do `getChild`, we can avoid the function call. Also adds symmetry between `getChild` and `registerChild`.