### PR TITLE
Bugfixes: positional attributes and trailing attributes

### DIFF
--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -113,18 +113,15 @@ var hasChangedAttrs = function(unused1, unused2, unused3, var_args) {
   var attrsChanged = false;
   var i;
 
-  for (i = ATTRIBUTES_OFFSET; i < arguments.length; i += 2) {
-    // Translate the from the arguments index (for values) to the attribute's
-    // ordinal. The attribute values are at arguments index 3, 5, 7, etc. To get
-    // the ordinal, need to subtract the offset and divide by 2
-    if (attrsArr[(i - ATTRIBUTES_OFFSET) >> 1] !== arguments[i + 1]) {
+  for (i = ATTRIBUTES_OFFSET; i < arguments.length; i += 1) {
+    if (attrsArr[i - ATTRIBUTES_OFFSET] !== arguments[i]) {
       attrsChanged = true;
       break;
     }
   }
 
-  for (; i < arguments.length; i += 2) {
-    attrsArr[(i - ATTRIBUTES_OFFSET) >> 1] = arguments[i + 1];
+  for (; i < arguments.length; i += 1) {
+    attrsArr[i - ATTRIBUTES_OFFSET] = arguments[i];
   }
 
   return attrsChanged;

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -111,17 +111,23 @@ var hasChangedAttrs = function(unused1, unused2, unused3, var_args) {
   var data = getData(this);
   var attrsArr = data.attrsArr;
   var attrsChanged = false;
-  var i;
+  var i = ATTRIBUTES_OFFSET;
+  var j = 0;
 
-  for (i = ATTRIBUTES_OFFSET; i < arguments.length; i += 1) {
-    if (attrsArr[i - ATTRIBUTES_OFFSET] !== arguments[i]) {
+  for (; i < arguments.length; i += 1, j += 1) {
+    if (attrsArr[j] !== arguments[i]) {
       attrsChanged = true;
       break;
     }
   }
 
-  for (; i < arguments.length; i += 1) {
-    attrsArr[i - ATTRIBUTES_OFFSET] = arguments[i];
+  for (; i < arguments.length; i += 1, j += 1) {
+    attrsArr[j] = arguments[i];
+  }
+
+  if (j < attrsArr.length) {
+    attrsChanged = true;
+    attrsArr.length = j;
   }
 
   return attrsChanged;

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -86,6 +86,19 @@ describe('attribute updates', () => {
 
       expect(el.getAttribute('data-expanded')).to.equal('bar');
     });
+
+    it('should update attribute in different position', () => {
+      patch(container, () => render({
+        'data-foo': 'foo'
+      }));
+      patch(container, () => render({
+        'data-bar': 'foo'
+      }));
+      var el = container.childNodes[0];
+
+      expect(el.getAttribute('data-bar')).to.equal('foo');
+      expect(el.getAttribute('data-foo')).to.equal(null);
+    });
   });
 
   describe('for function attributes', () => {

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -99,6 +99,18 @@ describe('attribute updates', () => {
       expect(el.getAttribute('data-bar')).to.equal('foo');
       expect(el.getAttribute('data-foo')).to.equal(null);
     });
+
+    it('should remove trailing attributes when missing', function() {
+      patch(container, () => render({
+        'data-foo': 'foo',
+        'data-bar': 'bar'
+      }));
+      patch(container, () => render({}));
+      var el = container.childNodes[0];
+
+      expect(el.getAttribute('data-foo')).to.equal(null);
+      expect(el.getAttribute('data-bar')).to.equal(null);
+    });
   });
 
   describe('for function attributes', () => {


### PR DESCRIPTION
Fixes two bugs:

1. [Swapping attribute positions may not update attributes](https://github.com/google/incremental-dom/commit/cdf2800889092ae68e628823694fdf5e1db45fdd)

  ```js
  var container = document.createElement(‘div’);
  patch(container, function() {
  elementOpen(‘div’, null, null, ‘class’, ‘test’);
  elementClose();
  });
  patch(container, function() {
  elementOpen(‘div’, null, null, ‘id’, ‘test’);
  elementClose();
  });

  var el = container.firstChild;
  el.className; // “test”
  el.id; // => “”
  ```

2. [Any missing trailing attributes won't be removed](https://github.com/google/incremental-dom/commit/fcba7ac2f2aa5fec6f568d21537b1eeca09db6ae)

  ```js
  var container = document.createElement(‘div’);
  patch(container, function() {
    elementOpen(‘div’, null, null, ‘class’, ‘test’, ‘id’, ‘test’);
    elementClose();
  });
  patch(container, function() {
    elementOpen(‘div’, null, null, ‘class’, ‘test’);
    elementClose();
  });

  var el = container.firstChild;
  el.id; // => “test”
  ```