### PR TITLE
Don't trash the keyMap

### DIFF
--- a/src/alignment.js
+++ b/src/alignment.js
@@ -17,7 +17,8 @@
 import {
     createNode,
     getChild,
-    registerChild
+    registerChild,
+    removeChild
 } from './nodes';
 import { getData } from './node_data';
 import { getWalker } from './walker';
@@ -125,7 +126,7 @@ var clearUnvisitedDOM = function(node) {
   while (lastChild !== lastVisitedChild) {
     var key = hasKeyMap && getData(lastChild).key;
     if (key) {
-      registerChild(node, key, null);
+      removeChild(node, key);
     }
 
     node.removeChild(lastChild);

--- a/src/alignment.js
+++ b/src/alignment.js
@@ -115,6 +115,7 @@ var clearUnvisitedDOM = function(node) {
   var data = getData(node);
   var lastChild = node.lastChild;
   var lastVisitedChild = data.lastVisitedChild;
+  var hasKeyMap = !!data.keyMap;
   data.lastVisitedChild = null;
 
   if (lastChild === lastVisitedChild) {
@@ -122,13 +123,14 @@ var clearUnvisitedDOM = function(node) {
   }
 
   while (lastChild !== lastVisitedChild) {
+    var key = hasKeyMap && getData(lastChild).key;
+    if (key) {
+      registerChild(node, key, null);
+    }
+
     node.removeChild(lastChild);
     lastChild = node.lastChild;
   }
-
-  // Invalidate the key map since we removed children. It will get recreated
-  // next time we need it.
-  data.keyMap = null;
 };
 
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -131,6 +131,17 @@ var getChild = function(parent, key) {
 
 
 /**
+ * Removes a child from the parent with the given key.
+ * @param {!Element} parent
+ * @param {?string} key
+ */
+var removeChild = function(parent, key) {
+  var keyMap = getData(parent).keyMap;
+  delete keyMap[key];
+};
+
+
+/**
  * Registers an element as being a child. The parent will keep track of the child
  * using the key. The child can be retrieved using the same key using
  * getKeyMap. The provided key should be unique within the parent Element.
@@ -147,6 +158,7 @@ var registerChild = function(parent, key, child) {
 export {
   createNode,
   getChild,
-  registerChild
+  registerChild,
+  removeChild
 };
 


### PR DESCRIPTION
This should be a win for any views that conditionally show a key'd child.

```js
patch(container, function() {
  condition = !condition;
  if (condition) {
    elementVoid('div', 'test');
  }
});
```

As long as there aren't a ton of dynamically named children being generated, I see this as saving an object allocation potentially every `patch` since you can both create _and_ remove the keyMap in a single run:

```js
patch(container, function() {
  condition = !condition;
  elementOpen('div');
    // This will create the keyMap
    elementVoid('div', condition);
  // This will destroy the keyMap, since the old div will be removed
  elementClose('div');
});
```