### PR TITLE
Normalize falsey keys to null

### DIFF
--- a/src/alignment.js
+++ b/src/alignment.js
@@ -27,15 +27,16 @@ var getWalker = require('./walker').getWalker;
 /**
  * Checks whether or not a given node matches the specified nodeName and key.
  *
- * @param {?Node} node An HTML node, typically an HTMLElement or Text.
+ * @param {!Node} node An HTML node, typically an HTMLElement or Text.
  * @param {?string} nodeName The nodeName for this node.
  * @param {?string} key An optional key that identifies a node.
  * @return {boolean} True if the node matches, false otherwise.
  */
 var matches = function(node, nodeName, key) {
-  return node &&
-         key === getKey(node) &&
-         nodeName === getNodeName(node);
+  if (key) {
+    return key === getKey(node);
+  }
+  return nodeName === getNodeName(node);
 };
 
 
@@ -57,7 +58,7 @@ var alignWithDOM = function(nodeName, key, statics) {
   var matchingNode;
 
   // Check to see if we have a node to reuse
-  if (matches(currentNode, nodeName, key)) {
+  if (currentNode && matches(currentNode, nodeName, key)) {
     matchingNode = currentNode;
   } else {
     var existingNode = key && getChild(parent, key);

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -47,7 +47,7 @@ function NodeData(nodeName, key) {
    * move within their parent.
    * @const
    */
-  this.key = key;
+  this.key = key || null;
 
   /**
    * Keeps track of children within this node by their key.

--- a/test/functional/keyed_items.js
+++ b/test/functional/keyed_items.js
@@ -37,6 +37,22 @@ describe('rendering with keys', () => {
       }
     }
 
+    it('should not modify DOM nodes with falsey keys', () => {
+      var slice = Array.prototype.slice;
+      var items = [
+        { key: null },
+        { key: undefined },
+        { key: '' },
+      ];
+
+      patch(container, () => render(items));
+      var nodes = slice.call(container.childNodes);
+
+      patch(container, () => render(items));
+
+      expect(slice.call(container.childNodes)).to.deep.equal(nodes);
+    });
+
     it('should not modify the DOM nodes when inserting', () => {
       var items = [
         { key: 'one' },


### PR DESCRIPTION
This is a tiny quibble: If `elementOpen` is used by only specifying the `tag`, the node's key will be initialized to `undefined`. This differs slightly with the way `initData` handles it, for instance.