### PR TITLE
Avoid elementOpenStart attributes memory leak

### DIFF
--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -228,7 +228,6 @@ var elementOpenStart = function(tag, key, statics) {
   argsBuilder[0] = tag;
   argsBuilder[1] = key;
   argsBuilder[2] = statics;
-  argsBuilder.length = ATTRIBUTES_OFFSET;
 };
 
 
@@ -258,6 +257,7 @@ var elementOpenEnd = function() {
   }
 
   elementOpen.apply(null, argsBuilder);
+  argsBuilder.length = 0;
 };
 
 


### PR DESCRIPTION
When using the `elementOpenStart`, `attr`, `elementOpenEnd` combo, any attributes apply to the element would be stored in the global argsBuilder array until the next call to `elementOpenStart`. If we clear `argsBuilder` on `elementOpenEnd`, we avoid a memory leak.