### PR TITLE
Add data parameter to patch

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -29,13 +29,14 @@ var walker = require('./walker'),
  * @param {!Element|!Document} node The Element or Document to patch.
  * @param {!function} fn A function containing elementOpen/elementClose/etc.
  *     calls that describe the DOM.
+ * @param {*} data An argument passed to fn to represent DOM state.
  */
-var patch = function(node, fn) {
+var patch = function(node, fn, data) {
   var prevWalker = getWalker();
   setWalker(new TreeWalker(node));
 
   firstChild();
-  fn();
+  fn(data);
   parentNode();
 
   setWalker(prevWalker);

--- a/test/functional/patch.js
+++ b/test/functional/patch.js
@@ -82,6 +82,16 @@ describe('patching an element', () => {
     expect(containerOne.textContent).to.equal('hello');
     expect(containerTwo.textContent).to.equal('foobar');
   });
+
+  it('should pass third argument to render function', () => {
+    function render(content) {
+      text(content);
+    }
+
+    patch(container, render, 'foobar');
+
+    expect(container.textContent).to.equal('foobar');
+  });
 });
 
 describe('patching a documentFragment', function() {


### PR DESCRIPTION
I think it's a pretty common case to want to pass a `data` argument to the render function that's passed to `patch`. It’d be nice if we didn't have to create another closure to do it.