### PR TITLE
Attributes module

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-var patch = require('./src/patch').patch;
 var elements = require('./src/virtual_elements');
+var patch = require('./src/patch').patch;
+var updateAttributes = require('./src/attributes').updateAttributes;
 
 module.exports = {
   patch: patch,
@@ -26,6 +27,7 @@ module.exports = {
   elementOpen: elements.elementOpen,
   elementClose: elements.elementClose,
   text: elements.text,
-  attr: elements.attr
+  attr: elements.attr,
+  updateAttributes: updateAttributes
 };
 

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-var getData = require('./node_data').getData;
+var nodeData = require('./node_data'),
+    getAttrsArr = nodeData.getAttrsArr,
+    getNewAttrs = nodeData.getNewAttrs,
+    getAttrs = nodeData.getAttrs;
 
 
 /**
@@ -35,8 +38,7 @@ var ATTRIBUTES_OFFSET = 3;
  *     as an HTML attribute, otherwise, it is set on node.
  */
 var applyAttr = function(el, name, value) {
-  var data = getData(el);
-  var attrs = data.attrs;
+  var attrs = getAttrs(el);
 
   if (attrs[name] === value) {
     return;
@@ -94,8 +96,7 @@ var applyStyle = function(el, style) {
  * @return {?Array<*>} The changed attributes, if any have changed.
  */
 var changedAttributes = function(unused1, unused2, unused3, var_args) {
-  var data = getData(this);
-  var attrsArr = data.attrsArr;
+  var attrsArr = getAttrsArr(this);
   var attrsChanged = false;
   var i = ATTRIBUTES_OFFSET;
   var j = 0;
@@ -174,8 +175,7 @@ var updateChangedAttributes = function(el, attributes) {
  * @return {!Object<string, *>} The updated newAttrs object.
  */
 var updateNewAttrs = function(el, attributes) {
-  var data = getData(el);
-  var newAttrs = data.newAttrs;
+  var newAttrs = getNewAttrs(el);
 
   for (var attr in newAttrs) {
     newAttrs[attr] = undefined;

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -24,7 +24,7 @@
 function NodeData(nodeName, key) {
   /**
    * The attributes and their values.
-   * @const
+   * @const {!Object<string, *>}
    */
   this.attrs = {};
 
@@ -45,7 +45,7 @@ function NodeData(nodeName, key) {
   /**
    * The key used to identify this node, used to preserve DOM nodes when they
    * move within their parent.
-   * @const
+   * @const {?string}
    */
   this.key = key || null;
 
@@ -63,12 +63,13 @@ function NodeData(nodeName, key) {
 
   /**
    * The node name for this node.
-   * @const
+   * @const {string}
    */
   this.nodeName = nodeName;
 
   /**
-   * @const {string}
+   * The text content of a Text node.
+   * {string}
    */
   this.text = null;
 }
@@ -114,7 +115,7 @@ var getData = function(node) {
 
 
 /**
- * @param {?Node} node A node to get the key for.
+ * @param {!Node} node A node to get the key for.
  * @return {?string} The key for the Node, if applicable.
  */
 var getKey = function(node) {
@@ -123,11 +124,38 @@ var getKey = function(node) {
 
 
 /**
- * @param {?Node} node A node to get the node name for.
- * @return {?string} The node name for the Node, if applicable.
+ * @param {!Node} node A node to get the node name for.
+ * @return {string} The node name for the Node.
  */
 var getNodeName = function(node) {
   return getData(node).nodeName;
+};
+
+
+/**
+ * @param {!Node} node A node to get the attributes hash for.
+ * @return {!Object<string, *>} The attributes for the Node.
+ */
+var getAttrs = function(node) {
+  return getData(node).attrs;
+};
+
+
+/**
+ * @param {!Node} node A node to get attributes array for.
+ * @return {!Array<*>} The attributes array for the Node.
+ */
+var getAttrsArr = function(node) {
+  return getData(node).attrsArr;
+};
+
+
+/**
+ * @param {!Node} node A node to get the incoming attributes for.
+ * @return {!Object<string, *>} The incoming attributes for the Node.
+ */
+var getNewAttrs = function(node) {
+  return getData(node).newAttrs;
 };
 
 
@@ -136,6 +164,9 @@ module.exports = {
   getData: getData,
   initData: initData,
   getKey: getKey,
-  getNodeName: getNodeName
+  getNodeName: getNodeName,
+  getAttrs: getAttrs,
+  getAttrsArr: getAttrsArr,
+  getNewAttrs: getNewAttrs
 };
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -19,7 +19,7 @@ var nodeData = require('./node_data'),
     getKey = nodeData.getKey,
     initData = nodeData.initData;
 var getNamespaceForTag = require('./namespace').getNamespaceForTag;
-var updateAttributes = require('./attributes').updateAttributes;
+var staticAttributes = require('./attributes').staticAttributes;
 
 
 /**
@@ -44,7 +44,7 @@ var createElement = function(doc, tag, key, statics) {
   initData(el, tag, key);
 
   if (statics) {
-    updateAttributes(el, statics);
+    staticAttributes(el, statics);
   }
 
   return el;

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-var updateAttribute = require('./attributes').updateAttribute;
 var nodeData = require('./node_data'),
     getData = nodeData.getData,
     getKey = nodeData.getKey,
     initData = nodeData.initData;
 var getNamespaceForTag = require('./namespace').getNamespaceForTag;
+var updateAttributes = require('./attributes').updateAttributes;
 
 
 /**
@@ -44,9 +44,7 @@ var createElement = function(doc, tag, key, statics) {
   initData(el, tag, key);
 
   if (statics) {
-    for (var i = 0; i < statics.length; i += 2) {
-      updateAttribute(el, statics[i], statics[i + 1]);
-    }
+    updateAttributes(el, statics);
   }
 
   return el;

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -15,11 +15,9 @@
  */
 
 var alignWithDOM = require('./alignment').alignWithDOM;
-var attributes = require('./attributes'),
-    changedAttributes = attributes.changedAttributes,
-    updateChangedAttributes = attributes.updateChangedAttributes;
 var getData = require('./node_data').getData;
 var getWalker = require('./walker').getWalker;
+var updateAttributesInternal = require('./attributes').updateAttributesInternal;
 var traversal = require('./traversal'),
     firstChild = traversal.firstChild,
     nextSibling = traversal.nextSibling,
@@ -102,11 +100,7 @@ var elementOpen = function(tag, key, statics, var_args) {
   }
 
   var node = alignWithDOM(tag, key, statics);
-
-  var changed = changedAttributes.apply(node, arguments);
-  if (changed) {
-    updateChangedAttributes(node, changed);
-  }
+  updateAttributesInternal.apply(node, arguments);
 
   firstChild();
   return node;

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -33,7 +33,7 @@ var traversal = require('./traversal'),
 var argsBuilder = [];
 
 /**
- * Verify if the script are running in production.
+ * Verify if the script is running in production.
  * @type {boolean}
  * @const
  */

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -15,21 +15,15 @@
  */
 
 var alignWithDOM = require('./alignment').alignWithDOM;
-var updateAttribute = require('./attributes').updateAttribute;
+var attributes = require('./attributes'),
+    changedAttributes = attributes.changedAttributes,
+    updateChangedAttributes = attributes.updateChangedAttributes;
 var getData = require('./node_data').getData;
 var getWalker = require('./walker').getWalker;
 var traversal = require('./traversal'),
     firstChild = traversal.firstChild,
     nextSibling = traversal.nextSibling,
     parentNode = traversal.parentNode;
-
-
-/**
- * The offset in the virtual element declaration where the attributes are
- * specified.
- * @const
- */
-var ATTRIBUTES_OFFSET = 3;
 
 
 /**
@@ -89,94 +83,6 @@ if (!IS_PRODUCTION) {
 
 
 /**
- * Checks to see if one or more attributes have changed for a given
- * Element. When no attributes have changed, this function is much faster than
- * checking each individual argument. When attributes have changed, the overhead
- * of this function is minimal.
- *
- * This function is called in the context of the Element and the arguments from
- * elementOpen-like function so that the arguments are not de-optimized.
- *
- * @this {Element} The Element to check for changed attributes.
- * @param {*} unused1
- * @param {*} unused2
- * @param {*} unused3
- * @param {...*} var_args Attribute name/value pairs of the dynamic attributes
- *     for the Element.
- * @return {boolean} True if the Element has one or more changed attributes,
- *     false otherwise.
- */
-var hasChangedAttrs = function(unused1, unused2, unused3, var_args) {
-  var data = getData(this);
-  var attrsArr = data.attrsArr;
-  var attrsChanged = false;
-  var i = ATTRIBUTES_OFFSET;
-  var j = 0;
-
-  for (; i < arguments.length; i += 1, j += 1) {
-    if (attrsArr[j] !== arguments[i]) {
-      attrsChanged = true;
-      break;
-    }
-  }
-
-  for (; i < arguments.length; i += 1, j += 1) {
-    attrsArr[j] = arguments[i];
-  }
-
-  if (j < attrsArr.length) {
-    attrsChanged = true;
-    attrsArr.length = j;
-  }
-
-  return attrsChanged;
-};
-
-
-/**
- * Updates the newAttrs object for an Element.
- *
- * This function is called in the context of the Element and the arguments from
- * elementOpen-like function so that the arguments are not de-optimized.
- *
- * @this {Element} The Element to update newAttrs for.
- * @param {*} unused1
- * @param {*} unused2
- * @param {*} unused3
- * @param {...*} var_args Attribute name/value pairs of the dynamic attributes
- *     for the Element.
- * @return {!Object<string, *>} The updated newAttrs object.
- */
-var updateNewAttrs = function(unused1, unused2, unused3, var_args) {
-  var node = this;
-  var data = getData(node);
-  var newAttrs = data.newAttrs;
-
-  for (var attr in newAttrs) {
-    newAttrs[attr] = undefined;
-  }
-
-  for (var i = ATTRIBUTES_OFFSET; i < arguments.length; i += 2) {
-    newAttrs[arguments[i]] = arguments[i + 1];
-  }
-
-  return newAttrs;
-};
-
-
-/**
- * Updates the attributes for a given Element.
- * @param {!Element} node
- * @param {!Object<string,*>} newAttrs The new attributes for node
- */
-var updateAttributes = function(node, newAttrs) {
-  for (var attr in newAttrs) {
-    updateAttribute(node, attr, newAttrs[attr]);
-  }
-};
-
-
-/**
  * Declares a virtual Element at the current location in the document. This
  * corresponds to an opening tag and a elementClose tag is required.
  * @param {string} tag The element's tag.
@@ -197,9 +103,9 @@ var elementOpen = function(tag, key, statics, var_args) {
 
   var node = alignWithDOM(tag, key, statics);
 
-  if (hasChangedAttrs.apply(node, arguments)) {
-    var newAttrs = updateNewAttrs.apply(node, arguments);
-    updateAttributes(node, newAttrs);
+  var changed = changedAttributes.apply(node, arguments);
+  if (changed) {
+    updateChangedAttributes(node, changed);
   }
 
   firstChild();

--- a/test/functional/update_attributes.js
+++ b/test/functional/update_attributes.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2015 The Incremental DOM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var IncrementalDOM = require('../../index'),
+    patch = IncrementalDOM.patch,
+    elementVoid = IncrementalDOM.elementVoid,
+    updateAttributes = IncrementalDOM.updateAttributes;
+
+describe('attribute updates', () => {
+  var container;
+  var el;
+
+  function render() {
+    el = elementVoid('div', '', ['data-expanded', 'true'], 'data-foo', 'foo');
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    patch(container, render);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('should add attributes', () => {
+    updateAttributes(el, 'data-bar', 'bar')
+
+    expect(el.getAttribute('data-bar')).to.equal('bar');
+  });
+
+  it('should update static attributes', () => {
+    updateAttributes(el, 'data-expanded', 'bar')
+
+    expect(el.getAttribute('data-expanded')).to.equal('bar');
+  });
+
+  it('should update dynamic attributes', () => {
+    updateAttributes(el, 'data-foo', 'bar')
+
+    expect(el.getAttribute('data-foo')).to.equal('bar');
+  });
+
+  it('should remove attributes when undefined', () => {
+    updateAttributes(el, 'data-foo', undefined);
+
+    expect(el.getAttribute('data-foo')).to.equal(null);
+  });
+
+});
+

--- a/test/functional/virtual_attributes.js
+++ b/test/functional/virtual_attributes.js
@@ -34,7 +34,7 @@ describe('virtual attribute updates', () => {
   });
 
   describe('for conditional attributes', () => {
-    function render(obj) {  
+    function render(obj) {
       elementOpenStart('div', '', []);
         if (obj.key) {
           attr('data-expanded', obj.key);


### PR DESCRIPTION
- Moves attributes related functions into the `attributes` module
- Adds a few `node_data` getters
  - I'm ambivalent, but following the lead of `getKey` and `getNodeName`
- Reworks `hasChangedAttrs` and `updateNewAttrs` to avoid a second `#apply` call.