### PR TITLE
Add elementPlaceholder

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = {
   elementOpenEnd: elements.elementOpenEnd,
   elementOpen: elements.elementOpen,
   elementClose: elements.elementClose,
+  elementPlaceholder: elements.elementPlaceholder,
   text: elements.text,
   attr: elements.attr,
   attributes: attributes

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -75,6 +75,18 @@ if (!IS_PRODUCTION) {
   };
 
 
+  /**
+  * Makes sure that the caller provided a key for the placeholder.
+  * @param {string} key The key used to identify this element.
+  */
+  var assertPlaceholderHasKey = function(key) {
+      if (!key) {
+        throw new Error('Was expecting a key to be provided with the ' +
+            'placeholder.');
+      }
+  };
+
+
   /** Updates the state to being in an attribute declaration. */
   var setInAttributes = function() {
     inAttributes = true;
@@ -326,6 +338,35 @@ var text = function(value) {
   nextSibling();
 };
 
+/**
+ * Declares a virtual Element at the current location in the document that
+ * represents a placeholder without specific content.
+ * @param {string} tag The element's tag.
+ * @param {string} key The key used to identify this element.
+ * @param {?Array<*>} statics An array of attribute name/value pairs of the
+ *     static attributes for the Element. These will only be set once when the
+ *     Element is created.
+ * @param {...*} var_args Attribute name/value pairs of the dynamic attributes
+ *     for the Element.
+ * @return {!Element} The corresponding Element.
+ */
+var elementPlaceholder = function(tag, key, statics, var_args) {
+  if (!IS_PRODUCTION) {
+    assertNotInAttributes();
+    assertPlaceholderHasKey(key);
+  }
+
+  var node = alignWithDOM(tag, key, statics);
+
+  if (hasChangedAttrs.apply(node, arguments)) {
+    var newAttrs = updateNewAttrs.apply(node, arguments);
+    updateAttributes(node, newAttrs);
+  }
+
+  nextSibling();
+  return node;
+};
+
 
 /** */
 module.exports = {
@@ -334,6 +375,7 @@ module.exports = {
   elementOpen: elementOpen,
   elementVoid: elementVoid,
   elementClose: elementClose,
+  elementPlaceholder: elementPlaceholder,
   text: text,
   attr: attr
 };

--- a/test/functional/placeholder.js
+++ b/test/functional/placeholder.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2015 The Incremental DOM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var IncrementalDOM = require('../../index'),
+    patch = IncrementalDOM.patch,
+    elementOpen = IncrementalDOM.elementOpen,
+    elementClose = IncrementalDOM.elementClose,
+    elementVoid = IncrementalDOM.elementVoid,
+    elementPlaceholder = IncrementalDOM.elementPlaceholder;
+
+describe('placeholders', () => {
+  var container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  describe('without an existing DOM element', () => {
+    var el;
+
+    beforeEach(() => {
+      patch(container, () => {
+        el = elementPlaceholder('div', 'placeholder', ['class', 'someClass'], 'data-foo', 'bar');
+      });
+    });
+
+    it('should render with the specified tag', () => {
+      expect(el.tagName).to.equal('DIV');
+    });
+
+    it('should render with static attributes', () => {
+      expect(el.className).to.equal('someClass');
+    });
+
+    it('should render with dynamic attributes', () => {
+      expect(el.getAttribute('data-foo')).to.equal('bar');
+    });
+  });
+
+  describe('with an existing DOM element', () => {
+    var div;
+    var el;
+    var child;
+
+    beforeEach(() => {
+      patch(container, function() {
+        div = elementPlaceholder('div', 'placeholder');
+        patch(div, function() {
+          child = elementVoid('div', null, ['id', 'child']);
+        });
+      });
+
+      patch(container, () => {
+        el = elementPlaceholder('span', 'placeholder', ['class', 'someClass'], 'data-foo', 'bar');
+      });
+    });
+
+    it('should keep the element', () => {
+      expect(el).to.equal(div);
+      expect(div.tagName).to.equal('DIV');
+    });
+
+    it('should not set static attributes', () => {
+      expect(div.getAttribute('class')).to.equal(null);
+    });
+
+    it('should set dynamic attributes', () => {
+      expect(div.getAttribute('data-foo')).to.equal('bar');
+    });
+
+    it('should leave any decedents unaltered', () => {
+      expect(child.parentNode).to.equal(div);
+    });
+  });
+});
+


### PR DESCRIPTION
It's impossible to build large scale Backbone apps without composing
subviews into an overall parent view. The challenge with the normal
render-string->jQuery.html was preserving a subview's element inside the
re-rendered parent — `jQuery#html` wipes out all nodes (and events) and
resets everything in the parent.

```html
<!-- parent's template -->
<div id="subview" class="empty"></div>

<!-- subview's template -->
<span>Subview's content</span>

<!-- fully rendered content -->
<div>
  <div id="subview">
    <span>Subview's content</span>
  </div>
</div>
```

```js
// Rerender parent
parent.render();
```

```html
<div>
  <!-- subview just got wiped out
       it now references a detached node -->
  <div id="subview" class="empty"></div>
</div>
```

For the longest time, devs would get around this by either rendering,
then looping through all the subviews and calling `#setElement` with a
newly rendered DOM node (recreating event listeners), then re-render the
subview. Or the much faster way was to detach subviews first, re-render,
then swap the newly rendered DOM node with element already attached to
the subview.

```js
// Painfully slow
parent.render();
parent.subViews.forEach((subview) => {
  subview.setElement(parent.$(subview.selector));
  subview.render();
});

// Faster
parent.subViews.forEach((subview) => {
  subview.detach();
});
parent.render();
parent.subViews.forEach((subview) => {
  parent.$(subview.selector).replaceWith(subview.el);
});
```

Essentially, the parent view renders placeholders into its template and
the subviews grab (and possibly replace) the placeholder to do their
thing.

Incremental DOM works pretty similarly to the current Backbone patterns.
It will preserve any event handlers since they're bound to the subview's
root element. But, any children will be wiped away, and attributes will
be updated on the subview's element (that one's the subview's concern,
not the parent template's).

But, Incremental DOM has the potential to handle this case natively...

```js
elementOpen('div');
  elementPlaceholder('div', 'subview', ['id', 'subview']);
elementClose('div');
```

`elementPlaceholder` will act as just a placeholder. If it doesn't
exist in the parent, it will be created. If it does, it's left alone
giving the subview full autonomy over its element. No more
`#setElement`, rebinding event listeners, and re-rendering. And no more
detach-find-reattaches. :smile: