### PR TITLE
Adding hooks to allow overriding of how attributes/properties are set.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@
 
 var patch = require('./src/patch').patch;
 var elements = require('./src/virtual_elements');
+var attributes = require('./src/attributes');
 
 module.exports = {
   patch: patch,
@@ -26,6 +27,7 @@ module.exports = {
   elementOpen: elements.elementOpen,
   elementClose: elements.elementClose,
   text: elements.text,
-  attr: elements.attr
+  attr: elements.attr,
+  attributes: attributes
 };
 

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -17,75 +17,75 @@
 var getData = require('./node_data').getData;
 
 
-/**
- * Applies an attribute or property to a given Element. If the value is a object
- * or a function (which includes null), it is set as a property on the Element.
- * Otherwise, the value is set as an attribute.
- * @param {!Element} el
- * @param {string} name The attribute's name.
- * @param {*} value The attribute's value. If the value is a string, it is set
- *     as an HTML attribute, otherwise, it is set on node.
- */
-var applyAttr = function(el, name, value) {
-  var data = getData(el);
-  var attrs = data.attrs;
+var attributes = {
+  /**
+   * Applies an attribute or property to a given Element. If the value is a
+   * object or a function (which includes null), it is set as a property on the
+   * Element. Otherwise, the value is set as an attribute.
+   * @param {!Element} el
+   * @param {string} name The attribute's name.
+   * @param {*} value The attribute's value. If the value is a string, it is set
+   *     as an HTML attribute, otherwise, it is set on node.
+   */
+  applyAttr: function(el, name, value) {
+    var type = typeof value;
 
-  if (attrs[name] === value) {
-    return;
-  }
-
-  var type = typeof value;
-
-  if (value === undefined) {
-    el.removeAttribute(name);
-  } else if (type === 'object' || type === 'function') {
-    el[name] = value;
-  } else {
-    el.setAttribute(name, value);
-  }
-
-  attrs[name] = value;
-};
-
-
-/**
- * Applies a style to an Element. No vendor prefix expansion is done for
- * property names/values.
- * @param {!Element} el
- * @param {string|Object<string,string>} style The style to set. Either a string
- *     of css or an object containing property-value pairs.
- */
-var applyStyle = function(el, style) {
-  if (typeof style === 'string' || style instanceof String) {
-    el.style.cssText = style;
-  } else {
-    el.style.cssText = '';
-
-    for (var prop in style) {
-      el.style[prop] = style[prop];
+    if (type === 'object' || type === 'function') {
+      el[name] = value;
+    } else if (value === undefined) {
+      el.removeAttribute(name);
+    } else {
+      el.setAttribute(name, value);
     }
-  }
-};
+  },
 
 
-/**
- * Updates a single attribute on an Element.
- * @param {!Element} el
- * @param {string} name The attribute's name.
- * @param {*} value The attribute's value. If the value is a string, it is set
- *     as an HTML attribute, otherwise, it is set on node.
- */
-var updateAttribute = function(el, name, value) {
-  if (name === 'style') {
-    applyStyle(el, value);
-  } else {
-    applyAttr(el, name, value);
+  /**
+   * Applies a style to an Element. No vendor prefix expansion is done for
+   * property names/values.
+   * @param {!Element} el
+   * @param {string|Object<string,string>} style The style to set. Either a
+   *     string of css or an object containing property-value pairs.
+   */
+  applyStyle: function(el, style) {
+    if (typeof style === 'string') {
+      el.style.cssText = style;
+    } else {
+      el.style.cssText = '';
+
+      for (var prop in style) {
+        el.style[prop] = style[prop];
+      }
+    }
+  },
+
+
+  /**
+   * Updates a single attribute on an Element.
+   * @param {!Element} el
+   * @param {string} name The attribute's name.
+   * @param {*} value The attribute's value. If the value is a string, it is set
+   *     as an HTML attribute, otherwise, it is set on node.
+   */
+  updateAttribute: function(el, name, value) {
+    var data = getData(el);
+    var attrs = data.attrs;
+
+    if (attrs[name] === value) {
+      return;
+    }
+
+    if (name === 'style') {
+      attributes.applyStyle(el, value);
+    } else {
+      attributes.applyAttr(el, name, value);
+    }
+
+    attrs[name] = value;
   }
 };
 
 
 /** */
-module.exports = {
-  updateAttribute: updateAttribute
-};
+module.exports = attributes;
 

--- a/test/functional/hooks.js
+++ b/test/functional/hooks.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2015 The Incremental DOM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var IncrementalDOM = require('../../index'),
+    patch = IncrementalDOM.patch,
+    elementVoid = IncrementalDOM.elementVoid,
+    attributes = IncrementalDOM.attributes;
+
+describe('library hooks', () => {
+  var container;
+  var sandbox = sinon.sandbox.create();
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    sandbox.restore();
+  });
+
+  describe('for deciding how attributes are set', () => {
+    function render(dynamicValue) {
+      elementVoid('div', null, ['staticName', 'staticValue'],
+          'dynamicName', dynamicValue);
+    }
+
+    beforeEach(() => {
+      sandbox.spy(attributes, 'applyAttr');
+    });
+  
+    it('should be called for static attributes', () => {
+      patch(container, render, 'dynamicValue');
+      var el = container.childNodes[0];
+
+      expect(attributes.applyAttr).calledWith(el, 'staticName', 'staticValue');
+    });
+
+    it('should be called for dynamic attributes', () => {
+      patch(container, render, 'dynamicValue');
+      var el = container.childNodes[0];
+
+      expect(attributes.applyAttr).calledWith(el, 'dynamicName', 'dynamicValue');
+    });
+
+    it('should be called on attribute update', () => {
+      patch(container, render, 'dynamicValueOne');
+      patch(container, render, 'dynamicValueTwo');
+      var el = container.childNodes[0];
+
+      expect(attributes.applyAttr).calledWith(el, 'dynamicName', 'dynamicValueTwo');
+    });
+
+    it('should allow only be called when attributes change', () => {
+      patch(container, render, 'dynamicValue');
+      patch(container, render, 'dynamicValue');
+
+      // Called once for the static attribute and once for the dynamic one
+      expect(attributes.applyAttr).calledTwice;
+    });
+  });
+});
+


### PR DESCRIPTION
This somewhat solves the following:

#57 - allows for setting innerHTML (on placeholder elements in #66) without requiring any security auditing if you don't want the feature. The core library won't do it, but it would be easy to implement if you wanted it. You could even require some special token be passed for setting innerHTML.
Points brought up in #67 - up to a higher level framework to decide what to do regarding attributes / properties

It might even make sense to entirely separate the following:

* Node alignment
* Node creation
* Attribute updates (even including decisions about caching)

and become more like a framework for creating an incremental DOM implementation, but I'll leave that for another day.

@cramforce