### PR TITLE
Return closed node

### DIFF
--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -269,6 +269,7 @@ var elementOpenEnd = function() {
  * Closes an open virtual Element.
  *
  * @param {string} tag The element's tag.
+ * @return {!Element} The corresponding Element.
  */
 var elementClose = function(tag) {
   if (!IS_PRODUCTION) {
@@ -276,7 +277,9 @@ var elementClose = function(tag) {
   }
 
   parentNode();
+  var node = getWalker().currentNode;
   nextSibling();
+  return node;
 };
 
 

--- a/test/functional/element_creation.js
+++ b/test/functional/element_creation.js
@@ -18,7 +18,9 @@ var IncrementalDOM = require('../../index'),
     patch = IncrementalDOM.patch,
     elementOpen = IncrementalDOM.elementOpen,
     elementClose = IncrementalDOM.elementClose,
-    elementVoid = IncrementalDOM.elementVoid;
+    elementVoid = IncrementalDOM.elementVoid,
+    elementOpenStart = IncrementalDOM.elementOpenStart,
+    elementOpenEnd = IncrementalDOM.elementOpenEnd;
 
 describe('element creation', () => {
   var container;
@@ -61,6 +63,49 @@ describe('element creation', () => {
       expect(el.getAttribute('data-foo')).to.equal('Hello');
       expect(el.getAttribute('data-bar')).to.equal('World');
     });
+
+    describe('should return DOM node', () => {
+      beforeEach(() => {
+        patch(container, () => {});
+      });
+
+      it('from elementOpen', () => {
+        patch(container, () => {
+          el = elementOpen('div');
+          elementClose('div');
+        });
+
+        expect(el).to.equal(container.childNodes[0]);
+      });
+
+      it('from elementClose', () => {
+        patch(container, () => {
+          elementOpen('div');
+          el = elementClose('div');
+        });
+
+        expect(el).to.equal(container.childNodes[0]);
+      });
+
+      it('from elementVoid', () => {
+        patch(container, () => {
+          el = elementVoid('div');
+        });
+
+        expect(el).to.equal(container.childNodes[0]);
+      });
+
+      it('from elementOpenEnd', () => {
+        patch(container, () => {
+          elementOpenStart('div');
+          el = elementOpenEnd('div');
+          elementClose('div');
+        });
+
+        expect(el).to.equal(container.childNodes[0]);
+      });
+    });
+
   });
 
   it('should allow creation without static attributes', () => {
@@ -114,27 +159,27 @@ describe('element creation', () => {
 
     it('should create svgs in the svg namespace', () => {
       var el = container.querySelector('svg');
-      expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg'); 
+      expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg');
     });
 
     it('should create descendants of svgs in the svg namespace', () => {
       var el = container.querySelector('circle');
-      expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg'); 
+      expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg');
     });
-    
+
     it('should have the svg namespace for foreignObjects', () => {
       var el = container.querySelector('svg').children[1];
-      expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg'); 
+      expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg');
     });
- 
+
     it('should revert to the xhtml namespace when encounering a foreignObject', () => {
       var el = container.querySelector('p');
-      expect(el.namespaceURI).to.equal('http://www.w3.org/1999/xhtml'); 
+      expect(el.namespaceURI).to.equal('http://www.w3.org/1999/xhtml');
     });
 
     it('should reset to the previous namespace after exiting a forignObject', () => {
       var el = container.querySelector('path');
-      expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg'); 
+      expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg');
     });
 
     it('should create children in the svg namespace when patching an svg', () => {
@@ -144,7 +189,7 @@ describe('element creation', () => {
       });
 
       var el = svg.querySelector('rect');
-      expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg'); 
+      expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg');
     });
   });
 });

--- a/test/functional/patch.js
+++ b/test/functional/patch.js
@@ -19,6 +19,8 @@ var IncrementalDOM = require('../../index'),
     elementOpen = IncrementalDOM.elementOpen,
     elementClose = IncrementalDOM.elementClose,
     elementVoid = IncrementalDOM.elementVoid,
+    elementOpenStart = IncrementalDOM.elementOpenStart,
+    elementOpenEnd = IncrementalDOM.elementOpenEnd,
     text = IncrementalDOM.text;
 
 describe('patching an element', () => {
@@ -59,6 +61,46 @@ describe('patching an element', () => {
       var child = container.childNodes[0];
 
       expect(child.getAttribute('tabindex')).to.equal('0');
+    });
+
+    describe('should return DOM node', () => {
+      var node;
+
+      it('from elementOpen', () => {
+        patch(container, () => {
+          node = elementOpen('div');
+          elementClose('div');
+        });
+
+        expect(node).to.equal(div);
+      });
+
+      it('from elementClose', () => {
+        patch(container, () => {
+          elementOpen('div');
+          node = elementClose('div');
+        });
+
+        expect(node).to.equal(div);
+      });
+
+      it('from elementVoid', () => {
+        patch(container, () => {
+          node = elementVoid('div');
+        });
+
+        expect(node).to.equal(div);
+      });
+
+      it('from elementOpenEnd', () => {
+        patch(container, () => {
+          elementOpenStart('div');
+          node = elementOpenEnd('div');
+          elementClose('div');
+        });
+
+        expect(node).to.equal(div);
+      });
     });
   });
 


### PR DESCRIPTION
While working on JSX -> Incremental DOM, I've noticed it's a common pattern to return JSX nodes in a `#map`:

```js
this.state.queries.map((query) => {
    return (<div>query</div>);
});
```

The easiest transformation compiles to:

```js
this.state.queries.map((query) => {
    return (elementOpen("div"), text(query), elementClose("div"));
});
```

But since the closed node isn't returned from `elementClose`, I'm actually returning a bunch of `undefined`s.