### PR TITLE
Changing from commonjs to es6 modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,10 +15,12 @@
  */
 
 var assign = require('lodash.assign');
+var babelify = require('babelify');
 var browserify = require('browserify');
 var buffer = require('vinyl-buffer');
 var del = require('del');
 var envify = require('envify');
+var es6ModuleToClosure = require("gulp-es6-module-to-closure");
 var git = require('gulp-git');
 var gjslint = require('gulp-gjslint');
 var gulp = require('gulp');
@@ -68,6 +70,7 @@ function lint() {
 
 function bundle(browserify, env) {
   return browserify
+    .transform(babelify)
     .transform(envify, env)
     .bundle()
     .on('error', gutil.log.bind(gutil, 'Browserify Error'))
@@ -114,6 +117,15 @@ function addDist() {
     }));
 }
 
+function toClosure() {
+  gulp.src('./src/**/*.js')
+    .pipe(es6ModuleToClosure({
+      root: 'src',
+      namespace: 'incrementaldom'
+    }))
+    .pipe(gulp.dest('./dist/closure'));
+}
+
 gulp.task('clean', clean);
 gulp.task('unit', unit);
 gulp.task('unit-watch', unitWatch);
@@ -123,5 +135,6 @@ gulp.task('js-watch', jsWatch);
 gulp.task('js-dist', jsDist);
 gulp.task('build', ['lint', 'unit', 'js']);
 gulp.task('dist', ['lint', 'unit', 'js-dist'], addDist);
+gulp.task('closure', toClosure);
 
 gulp.task('default', ['build']);

--- a/index.js
+++ b/index.js
@@ -15,19 +15,15 @@
  * limitations under the License.
  */
 
-var patch = require('./src/patch').patch;
-var elements = require('./src/virtual_elements');
-var attributes = require('./src/attributes');
-
-module.exports = {
-  patch: patch,
-  elementVoid: elements.elementVoid,
-  elementOpenStart: elements.elementOpenStart,
-  elementOpenEnd: elements.elementOpenEnd,
-  elementOpen: elements.elementOpen,
-  elementClose: elements.elementClose,
-  text: elements.text,
-  attr: elements.attr,
-  attributes: attributes
-};
+export { patch } from './src/patch';
+export {
+  elementVoid,
+  elementOpenStart,
+  elementOpenEnd,
+  elementOpen,
+  elementClose,
+  text,
+  attr,
+} from './src/virtual_elements';
+export { attributes } from './src/attributes';
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,7 +26,7 @@ module.exports = function(config) {
     browserify: {
       watch: true,
       debug: true,
-      transform: ['es6ify']
+      transform: ['babelify']
     },
 
     reporters: ['progress'],

--- a/package.json
+++ b/package.json
@@ -16,12 +16,13 @@
     "dist": "gulp dist"
   },
   "devDependencies": {
+    "babelify": "^6.1.3",
     "browserify": "^10.2.4",
     "chai": "^3.0.0",
     "del": "^1.2.0",
     "envify": "~3.4.0",
-    "es6ify": "~1.6.0",
     "gulp": "^3.9.0",
+    "gulp-es6-module-to-closure": "^1.0.7",
     "gulp-git": "~1.2.4",
     "gulp-gjslint": "~0.1.4",
     "gulp-sourcemaps": "~1.5.1",

--- a/src/alignment.js
+++ b/src/alignment.js
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-var nodes = require('./nodes'),
-    createNode = nodes.createNode,
-    getChild = nodes.getChild,
-    registerChild = nodes.registerChild;
-var nodeData = require('./node_data'),
-    getKey = nodeData.getKey,
-    getNodeName = nodeData.getNodeName;
-var getWalker = require('./walker').getWalker;
+import {
+    createNode,
+    getChild,
+    registerChild
+} from './nodes';
+import {
+    getKey,
+    getNodeName
+} from './node_data';
+import { getWalker } from './walker';
 
 
 /**
@@ -83,7 +85,7 @@ var alignWithDOM = function(nodeName, key, statics) {
 
 
 /** */
-module.exports = {
-  alignWithDOM: alignWithDOM
+export {
+  alignWithDOM
 };
 

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-var getData = require('./node_data').getData;
+import { getData } from './node_data';
 
 
 var attributes = {
@@ -87,5 +87,7 @@ var attributes = {
 
 
 /** */
-module.exports = attributes;
+export {
+  attributes
+};
 

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-var getWalker = require('./walker').getWalker;
+import { getWalker } from './walker';
 
 var SVG_NS = 'http://www.w3.org/2000/svg';
 
@@ -59,9 +59,9 @@ var getNamespaceForTag = function(tag) {
 
 
 /** */
-module.exports = {
-  enterTag: enterTag,
-  exitTag: exitTag,
-  getNamespaceForTag: getNamespaceForTag
+export {
+  enterTag,
+  exitTag,
+  getNamespaceForTag
 };
 

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -132,10 +132,10 @@ var getNodeName = function(node) {
 
 
 /** */
-module.exports = {
-  getData: getData,
-  initData: initData,
-  getKey: getKey,
-  getNodeName: getNodeName
+export {
+  getData,
+  initData,
+  getKey,
+  getNodeName
 };
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-var updateAttribute = require('./attributes').updateAttribute;
-var nodeData = require('./node_data'),
-    getData = nodeData.getData,
-    getKey = nodeData.getKey,
-    initData = nodeData.initData;
-var getNamespaceForTag = require('./namespace').getNamespaceForTag;
+import { attributes } from './attributes';
+import {
+    getData,
+    getKey,
+    initData
+} from './node_data';
+import { getNamespaceForTag } from './namespace';
+
 
 
 /**
@@ -45,7 +47,7 @@ var createElement = function(doc, tag, key, statics) {
 
   if (statics) {
     for (var i = 0; i < statics.length; i += 2) {
-      updateAttribute(el, statics[i], statics[i + 1]);
+      attributes.updateAttribute(el, statics[i], statics[i + 1]);
     }
   }
 
@@ -154,9 +156,9 @@ var registerChild = function(parent, key, child) {
 
 
 /** */
-module.exports = {
-  createNode: createNode,
-  getChild: getChild,
-  registerChild: registerChild
+export {
+  createNode,
+  getChild,
+  registerChild
 };
 

--- a/src/patch.js
+++ b/src/patch.js
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-var traversal = require('./traversal'),
-    firstChild = traversal.firstChild,
-    parentNode = traversal.parentNode;
-var TreeWalker = require('./tree_walker');
-var walker = require('./walker'),
-    getWalker = walker.getWalker,
-    setWalker = walker.setWalker;
+import {
+    firstChild,
+    parentNode
+} from './traversal';
+import { TreeWalker } from './tree_walker';
+import {
+    getWalker,
+    setWalker
+} from './walker';
+
 
 /**
  * @const {boolean}
@@ -71,7 +74,7 @@ var patch = function(node, fn, data) {
 
 
 /** */
-module.exports = {
-  patch: patch
+export {
+  patch
 };
 

--- a/src/traversal.js
+++ b/src/traversal.js
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-var getWalker = require('./walker').getWalker;
-var getData = require('./node_data').getData;
-var namespace = require('./namespace');
+import { getWalker } from './walker';
+import { getData } from './node_data';
+import {
+  enterTag,
+  exitTag
+} from './namespace';
 
 
 /**
@@ -25,7 +28,7 @@ var namespace = require('./namespace');
  */
 var enterNode = function(node) {
   var data = getData(node);
-  namespace.enterTag(data.nodeName);
+  enterTag(data.nodeName);
 };
 
 
@@ -40,7 +43,7 @@ var exitNode = function(node) {
   var lastVisitedChild = data.lastVisitedChild;
   data.lastVisitedChild = null;
 
-  namespace.exitTag(data.nodeName);
+  exitTag(data.nodeName);
 
   if (node.lastChild === lastVisitedChild) {
     return;
@@ -99,9 +102,9 @@ var parentNode = function() {
 
 
 /** */
-module.exports = {
-  firstChild: firstChild,
-  nextSibling: nextSibling,
-  parentNode: parentNode
+export {
+  firstChild,
+  nextSibling,
+  parentNode
 };
 

--- a/src/tree_walker.js
+++ b/src/tree_walker.js
@@ -102,5 +102,7 @@ TreeWalker.prototype.parentNode = function() {
 
 
 /** */
-module.exports = TreeWalker;
+export {
+  TreeWalker
+};
 

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-var alignWithDOM = require('./alignment').alignWithDOM;
-var updateAttribute = require('./attributes').updateAttribute;
-var getData = require('./node_data').getData;
-var getWalker = require('./walker').getWalker;
-var traversal = require('./traversal'),
-    firstChild = traversal.firstChild,
-    nextSibling = traversal.nextSibling,
-    parentNode = traversal.parentNode;
+import { alignWithDOM } from './alignment';
+import { attributes } from './attributes';
+import { getData } from './node_data';
+import { getWalker } from './walker';
+import {
+    firstChild,
+    nextSibling,
+    parentNode
+} from './traversal';
 
 
 /**
@@ -183,7 +184,7 @@ var updateNewAttrs = function(unused1, unused2, unused3, var_args) {
  */
 var updateAttributes = function(node, newAttrs) {
   for (var attr in newAttrs) {
-    updateAttribute(node, attr, newAttrs[attr]);
+    attributes.updateAttribute(node, attr, newAttrs[attr]);
   }
 };
 
@@ -344,13 +345,13 @@ var text = function(value) {
 
 
 /** */
-module.exports = {
-  elementOpenStart: elementOpenStart,
-  elementOpenEnd: elementOpenEnd,
-  elementOpen: elementOpen,
-  elementVoid: elementVoid,
-  elementClose: elementClose,
-  text: text,
-  attr: attr
+export {
+  elementOpenStart,
+  elementOpenEnd,
+  elementOpen,
+  elementVoid,
+  elementClose,
+  text,
+  attr
 };
 

--- a/src/walker.js
+++ b/src/walker.js
@@ -38,8 +38,8 @@ var setWalker = function(walker) {
 
 
 /** */
-module.exports = {
-  getWalker: getWalker,
-  setWalker: setWalker
+export {
+  getWalker,
+  setWalker
 };
 

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    elementOpenStart = IncrementalDOM.elementOpenStart,
-    elementOpenEnd = IncrementalDOM.elementOpenEnd,
-    elementAttr = IncrementalDOM.attr,
-    elementClose = IncrementalDOM.elementClose,
-    elementVoid = IncrementalDOM.elementVoid;
+import {
+    patch,
+    elementOpenStart,
+    elementOpenEnd,
+    attr,
+    elementClose,
+    elementVoid
+} from '../../index';
 
 describe('attribute updates', () => {
   var container;
@@ -37,8 +38,8 @@ describe('attribute updates', () => {
   describe('for conditional attributes', () => {
     function render(attrs) {
       elementOpenStart('div', '', []);
-      for (var attr in attrs) {
-          elementAttr(attr, attrs[attr]);
+      for (var attrName in attrs) {
+          attr(attrName, attrs[attrName]);
       }
       elementOpenEnd();
       elementClose('div');

--- a/test/functional/conditional_rendering.js
+++ b/test/functional/conditional_rendering.js
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    elementOpen = IncrementalDOM.elementOpen,
-    elementClose = IncrementalDOM.elementClose,
-    elementVoid = IncrementalDOM.elementVoid;
+import {
+    patch,
+    elementOpen,
+    elementClose,
+    elementVoid
+} from '../../index';
+
 
 describe('conditional rendering', () => {
   var container;

--- a/test/functional/element_creation.js
+++ b/test/functional/element_creation.js
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    elementOpen = IncrementalDOM.elementOpen,
-    elementClose = IncrementalDOM.elementClose,
-    elementVoid = IncrementalDOM.elementVoid,
-    elementOpenStart = IncrementalDOM.elementOpenStart,
-    elementOpenEnd = IncrementalDOM.elementOpenEnd;
+import {
+    patch,
+    elementOpen,
+    elementOpenStart,
+    elementOpenEnd,
+    elementClose,
+    elementVoid
+} from '../../index';
 
 describe('element creation', () => {
   var container;

--- a/test/functional/hooks.js
+++ b/test/functional/hooks.js
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    elementVoid = IncrementalDOM.elementVoid,
-    attributes = IncrementalDOM.attributes;
+import {
+    patch,
+    elementVoid,
+    attributes
+} from '../../index';
+
 
 describe('library hooks', () => {
   var container;

--- a/test/functional/keyed_items.js
+++ b/test/functional/keyed_items.js
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    elementVoid = IncrementalDOM.elementVoid;
+import {
+    patch,
+    elementVoid
+} from '../../index';
+
 
 describe('rendering with keys', () => {
   var container;

--- a/test/functional/patch.js
+++ b/test/functional/patch.js
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    elementOpen = IncrementalDOM.elementOpen,
-    elementClose = IncrementalDOM.elementClose,
-    elementVoid = IncrementalDOM.elementVoid,
-    elementOpenStart = IncrementalDOM.elementOpenStart,
-    elementOpenEnd = IncrementalDOM.elementOpenEnd,
-    text = IncrementalDOM.text;
+import {
+    patch,
+    elementOpen,
+    elementOpenStart,
+    elementOpenEnd,
+    elementClose,
+    elementVoid,
+    text
+} from '../../index';
+
 
 describe('patching an element', () => {
   var container;

--- a/test/functional/text_nodes.js
+++ b/test/functional/text_nodes.js
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    text = IncrementalDOM.text;
+import {
+    patch,
+    text
+} from '../../index';
+
 
 describe('text nodes', () => {
   var container;

--- a/test/functional/virtual_attributes.js
+++ b/test/functional/virtual_attributes.js
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
-var IncrementalDOM = require('../../index'),
-    patch = IncrementalDOM.patch,
-    elementOpenStart = IncrementalDOM.elementOpenStart,
-    elementOpenEnd = IncrementalDOM.elementOpenEnd,
-    elementClose = IncrementalDOM.elementClose,
-    attr = IncrementalDOM.attr;
+import {
+    patch,
+    elementOpen,
+    elementOpenStart,
+    elementOpenEnd,
+    elementClose,
+    attr
+} from '../../index';
+
 
 describe('virtual attribute updates', () => {
   var container;


### PR DESCRIPTION
Creating a branch that uses es6 modules that I will keep up to date with master. This is similar to the work done by @thejameskyle in #33, but still uses browserify instead of esperanto.

This branch also has a 'closure' build target that generates source files using goog.provide/goog.require in the dist/closure folder.

@cramforce 