### PR TITLE
Fixing two issues with keyed items.

### DIFF
--- a/src/alignment.js
+++ b/src/alignment.js
@@ -37,10 +37,12 @@ var dummy;
  */
 var matches = function(node, nodeName, key) {
   var data = getData(node);
-  if (key) {
-    return key === data.key;
-  }
-  return nodeName === data.nodeName;
+
+  // Key check is done using double equals as we want to treat a null key the
+  // same as undefined. This should be okay as the only values allowed are
+  // strings, null and undefined so the == semantics are not too weird.
+  return key == data.key &&
+         nodeName === data.nodeName;
 };
 
 
@@ -68,7 +70,7 @@ var alignWithDOM = function(nodeName, key, statics) {
 
     // Check to see if the node has moved within the parent or if a new one
     // should be created
-    if (existingNode) {
+    if (existingNode && matches(existingNode, nodeName, key)) {
       matchingNode = existingNode;
     } else {
       matchingNode = createNode(walker.doc, nodeName, key, statics);

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -47,7 +47,7 @@ function NodeData(nodeName, key) {
    * move within their parent.
    * @const
    */
-  this.key = key || null;
+  this.key = key;
 
   /**
    * Keeps track of children within this node by their key.

--- a/test/functional/conditional_rendering.js
+++ b/test/functional/conditional_rendering.js
@@ -53,7 +53,7 @@ describe('conditional rendering', () => {
       patch(container, () => render(false));
       var outer = container.childNodes[0];
 
-      expect(outer.childNodes.length).to.equal(2);
+      expect(outer.childNodes).to.have.length(2);
       expect(outer.childNodes[0].id).to.equal('one');
       expect(outer.childNodes[0].tagName).to.equal('DIV');
       expect(outer.childNodes[1].id).to.equal('two');
@@ -65,7 +65,7 @@ describe('conditional rendering', () => {
       patch(container, () => render(true));
       var outer = container.childNodes[0];
 
-      expect(outer.childNodes.length).to.equal(4);
+      expect(outer.childNodes).to.have.length(4);
       expect(outer.childNodes[0].id).to.equal('one');
       expect(outer.childNodes[0].tagName).to.equal('DIV');
       expect(outer.childNodes[1].id).to.equal('conditional-one');
@@ -94,7 +94,7 @@ describe('conditional rendering', () => {
       patch(container, () => render(false));
       var outer = container.childNodes[0];
 
-      expect(outer.childNodes.length).to.equal(0);
+      expect(outer.childNodes).to.have.length(0);
     });
   });
 
@@ -123,7 +123,7 @@ describe('conditional rendering', () => {
       patch(container, () => render(false));
       var outer = container.childNodes[0];
 
-      expect(outer.childNodes.length).to.equal(2);
+      expect(outer.childNodes).to.have.length(2);
       expect(outer.childNodes[0].id).to.equal('one');
       expect(outer.childNodes[0].tagName).to.equal('DIV');
       expect(outer.childNodes[1].id).to.equal('two');


### PR DESCRIPTION
Fixing an item with a key being re-used by an item without a key.
Fixing an item with a matching key reusing the wrong tag.

You might want to take a look at this using &w=0 as I removed one level of indentation in the tests. The first issue is a bit subtle, but basically if you went from:
```
elementVoid('div', 'foo');
```
to:
```
elementVoid('div');
elementVoid('div', 'foo');
```
You would end up with just one node as the code was matching the existing node both for the first and second elements in the new state.

@cramforce 