### PR TITLE
Props

### DIFF
--- a/src/alignment.js
+++ b/src/alignment.js
@@ -19,7 +19,6 @@ import {
     getChild,
     registerChild
 } from './nodes';
-import { getData } from './node_data';
 import { getWalker } from './walker';
 
 
@@ -36,13 +35,11 @@ var dummy;
  * @return {boolean} True if the node matches, false otherwise.
  */
 var matches = function(node, nodeName, key) {
-  var data = getData(node);
-
   // Key check is done using double equals as we want to treat a null key the
   // same as undefined. This should be okay as the only values allowed are
   // strings, null and undefined so the == semantics are not too weird.
-  return key == data.key &&
-         nodeName === data.nodeName;
+  return key == node['__incrementalDOMKey'] &&
+         nodeName === node['__incrementalDOMNodeName'];
 };
 
 
@@ -93,9 +90,8 @@ var alignWithDOM = function(nodeName, key, statics) {
  * @param {!Element} node
  */
 var clearUnvisitedDOM = function(node) {
-  var data = getData(node);
-  var lastVisitedChild = data.lastVisitedChild;
-  data.lastVisitedChild = null;
+  var lastVisitedChild = node['__incrementalDOMLastVisitedChild'];
+  node['__incrementalDOMLastVisitedChild'] = null;
 
   if (node.lastChild === lastVisitedChild) {
     return;
@@ -107,7 +103,7 @@ var clearUnvisitedDOM = function(node) {
 
   // Invalidate the key map since we removed children. It will get recreated
   // next time we need it.
-  data.keyMap = null;
+  node['__incrementalDOMKeyMap'] = null;
 };
 
 

--- a/src/alignment.js
+++ b/src/alignment.js
@@ -37,10 +37,12 @@ var dummy;
  */
 var matches = function(node, nodeName, key) {
   var data = getData(node);
-  if (key) {
-    return key === data.key;
-  }
-  return nodeName === data.nodeName;
+
+  // Key check is done using double equals as we want to treat a null key the
+  // same as undefined. This should be okay as the only values allowed are
+  // strings, null and undefined so the == semantics are not too weird.
+  return key == data.key &&
+         nodeName === data.nodeName;
 };
 
 
@@ -68,7 +70,7 @@ var alignWithDOM = function(nodeName, key, statics) {
 
     // Check to see if the node has moved within the parent or if a new one
     // should be created
-    if (existingNode) {
+    if (existingNode && matches(existingNode, nodeName, key)) {
       matchingNode = existingNode;
     } else {
       matchingNode = createNode(walker.doc, nodeName, key, statics);

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { getData } from './node_data';
-
 
 var attributes = {
   /**
@@ -68,8 +66,7 @@ var attributes = {
    *     as an HTML attribute, otherwise, it is set on node.
    */
   updateAttribute: function(el, name, value) {
-    var data = getData(el);
-    var attrs = data.attrs;
+    var attrs = el['__incrementalDOMAttrs'];
 
     if (attrs[name] === value) {
       return;

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -16,106 +16,75 @@
 
 
 /**
- * Keeps track of information needed to perform diffs for a given DOM node.
- * @param {?string} nodeName
- * @param {?string} key
- * @constructor
- */
-function NodeData(nodeName, key) {
-  /**
-   * The attributes and their values.
-   * @const
-   */
-  this.attrs = {};
-
-  /**
-   * An array of attribute name/value pairs, used for quickly diffing the
-   * incomming attributes to see if the DOM node's attributes need to be
-   * updated.
-   * @const {Array<*>}
-   */
-  this.attrsArr = [];
-
-  /**
-   * The incoming attributes for this Node, before they are updated.
-   * @const {!Object<string, *>}
-   */
-  this.newAttrs = {};
-
-  /**
-   * The key used to identify this node, used to preserve DOM nodes when they
-   * move within their parent.
-   * @const
-   */
-  this.key = key;
-
-  /**
-   * Keeps track of children within this node by their key.
-   * {?Object<string, Node>}
-   */
-  this.keyMap = null;
-
-  /**
-   * The last child to have been visited within the current pass.
-   * {?Node}
-   */
-  this.lastVisitedChild = null;
-
-  /**
-   * The node name for this node.
-   * @const
-   */
-  this.nodeName = nodeName;
-
-  /**
-   * @const {string}
-   */
-  this.text = null;
-}
-
-
-/**
- * Initializes a NodeData object for a Node.
+ * Initializes the fields needed for a node.
  *
- * @param {!Node} node The node to initialize data for.
+ * @param {!Document|!Element} node The node to initialize data for.
  * @param {string} nodeName The node name of node.
  * @param {?string} key The key that identifies the node.
- * @return {!NodeData} The newly initialized data object
  */
 var initData = function(node, nodeName, key) {
-  var data = new NodeData(nodeName, key);
-  node['__incrementalDOMData'] = data;
-  return data;
+  node['__incrementalDOMKey'] = key;
+  node['__incrementalDOMNodeName'] = nodeName;
+  node['__incrementalDOMLastVisitedChild'] = null;
+  node['__incrementalDOMAttrsArr'] = [];
+  node['__incrementalDOMAttrs'] = {};
+  node['__incrementalDOMNewAttrs'] = {};
+  node['__incrementalDOMKeyMap'] = null;
 };
 
 
 /**
- * Retrieves the NodeData object for a Node, creating it if necessary.
- *
- * @param {!Node} node The node to retrieve the data for.
- * @return {NodeData} The NodeData for this Node.
+ * @param {!Text} node The Text node to initialize data for.
  */
-var getData = function(node) {
-  var data = node['__incrementalDOMData'];
+var initTextData = function(node) {
+  node['__incrementalDOMKey'] = null;
+  node['__incrementalDOMNodeName'] = '#text';
+  node['__incrementalDOMText'] = null;
+};
 
-  if (!data) {
-    var nodeName = node.nodeName.toLowerCase();
-    var key = null;
 
-    if (node instanceof Element) {
-      key = node.getAttribute('key');
-    }
+/**
+ * Imports a single existing node, initializing the data fields.
+ * @param {!Document|!Element} node
+ */
+var importSingleNode = function(node) {
+  var nodeName = node.nodeName.toLowerCase();
+  var key = null;
 
-    data = initData(node, nodeName, key);
+  if (node instanceof Element) {
+    key = node.getAttribute('key');
   }
 
-  return data;
+  if (nodeName === '#text') {
+    initTextData(node);
+  } else {
+    initData(node, nodeName, key);
+  }
+};
+
+
+/**
+ * Imports a node and its subtree, initializing the data fields.
+ * @param {!Document|!Element} node
+ */
+var importNode = function(node) {
+  if (node['__incrementalDOMNodeName']) {
+    return;
+  }
+
+  var iter = document.createNodeIterator(node);
+  var current;
+
+  while (current = iter.nextNode()) {
+    importSingleNode(current);
+  }
 };
 
 
 /** */
 export {
-  getData,
-  initData
+  initData,
+  initTextData,
+  importNode
 };
 

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -47,7 +47,7 @@ function NodeData(nodeName, key) {
    * move within their parent.
    * @const
    */
-  this.key = key || null;
+  this.key = key;
 
   /**
    * Keeps track of children within this node by their key.

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -16,8 +16,8 @@
 
 import { attributes } from './attributes';
 import {
-    getData,
-    initData
+  initData,
+  initTextData
 } from './node_data';
 import { getNamespaceForTag } from './namespace';
 
@@ -61,8 +61,8 @@ var createElement = function(doc, tag, key, statics) {
  * Creates a Node, either a Text or an Element depending on the node name
  * provided.
  * @param {!Document} doc The document with which to create the Node.
- * @param {string} nodeName The tag if creating an element or #text to create
- *     a Text.
+ * @param {?string} nodeName The tag if creating an element or undefined to
+ *     create a Text.
  * @param {?string} key A key to identify the Element.
  * @param {?Array<*>} statics The static data to initialize the Node
  *     with. For an Element, an array of attribute name/value pairs of
@@ -71,7 +71,9 @@ var createElement = function(doc, tag, key, statics) {
  */
 var createNode = function(doc, nodeName, key, statics) {
   if (nodeName === '#text') {
-    return doc.createTextNode('');
+    var node = doc.createTextNode('');
+    initTextData(node);
+    return node;
   }
 
   return createElement(doc, nodeName, key, statics);
@@ -91,7 +93,7 @@ var createKeyMap = function(el) {
 
   for (var i = 0; i < count; i += 1) {
     var child = children[i];
-    var key = getData(child).key;
+    var key = child['__incrementalDOMKey'];
 
     if (key) {
       map[key] = child;
@@ -109,13 +111,13 @@ var createKeyMap = function(el) {
  * @return {!Object<string,!Node>} A mapping of keys to child Nodes
  */
 var getKeyMap = function(el) {
-  var data = getData(el);
+  var keyMap = el['__incrementalDOMKeyMap'];
 
-  if (!data.keyMap) {
-    data.keyMap = createKeyMap(el);
+  if (!keyMap) {
+    keyMap = el['__incrementalDOMKeyMap'] = createKeyMap(el);
   }
 
-  return data.keyMap;
+  return keyMap;
 };
 
 

--- a/src/patch.js
+++ b/src/patch.js
@@ -24,6 +24,7 @@ import {
     setWalker
 } from './walker';
 import { clearUnvisitedDOM } from './alignment';
+import { importNode } from './node_data';
 
 
 // For https://github.com/esperantojs/esperanto/issues/187
@@ -61,6 +62,8 @@ if (process.env.NODE_ENV !== 'production') {
  * @param {*} data An argument passed to fn to represent DOM state.
  */
 var patch = function(node, fn, data) {
+  importNode(node);
+
   var prevWalker = getWalker();
   setWalker(new TreeWalker(node));
 

--- a/src/traversal.js
+++ b/src/traversal.js
@@ -15,7 +15,6 @@
  */
 
 import { getWalker } from './walker';
-import { getData } from './node_data';
 import {
   enterTag,
   exitTag
@@ -31,8 +30,7 @@ var dummy;
  * @param {!Element} node
  */
 var enterNode = function(node) {
-  var data = getData(node);
-  enterTag(data.nodeName);
+  enterTag(node['__incrementalDOMNodeName']);
 };
 
 
@@ -41,8 +39,7 @@ var enterNode = function(node) {
  * @param {!Element} node
  */
 var exitNode = function(node) {
-  var data = getData(node);
-  exitTag(data.nodeName);
+  exitTag(node['__incrementalDOMNodeName']);
 };
 
 
@@ -53,8 +50,7 @@ var exitNode = function(node) {
 var markVisited = function(node) {
   var walker = getWalker();
   var parent = walker.getCurrentParent();
-  var data = getData(parent);
-  data.lastVisitedChild = node;
+  parent['__incrementalDOMLastVisitedChild'] = node;
 };
 
 

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -19,7 +19,6 @@ import {
   clearUnvisitedDOM
 } from './alignment';
 import { attributes } from './attributes';
-import { getData } from './node_data';
 import { getWalker } from './walker';
 import {
     firstChild,
@@ -82,11 +81,11 @@ if (process.env.NODE_ENV !== 'production') {
    */
   var assertCloseMatchesOpenTag = function(tag) {
     var closingNode = getWalker().getCurrentParent();
-    var data = getData(closingNode);
+    var nodeName = closingNode['__incrementalDOMNodeName'];
 
-    if (tag !== data.nodeName) {
+    if (tag !== nodeName) {
       throw new Error('Received a call to close ' + tag + ' but ' +
-            data.nodeName + ' was open.');
+            nodeName + ' was open.');
     }
   };
 
@@ -123,8 +122,7 @@ if (process.env.NODE_ENV !== 'production') {
  *     false otherwise.
  */
 var hasChangedAttrs = function(unused1, unused2, unused3, var_args) {
-  var data = getData(this);
-  var attrsArr = data.attrsArr;
+  var attrsArr = this['__incrementalDOMAttrsArr'];
   var attrsChanged = false;
   var i = ATTRIBUTES_OFFSET;
   var j = 0;
@@ -164,9 +162,7 @@ var hasChangedAttrs = function(unused1, unused2, unused3, var_args) {
  * @return {!Object<string, *>} The updated newAttrs object.
  */
 var updateNewAttrs = function(unused1, unused2, unused3, var_args) {
-  var node = this;
-  var data = getData(node);
-  var newAttrs = data.newAttrs;
+  var newAttrs = this['__incrementalDOMNewAttrs'];
 
   for (var attr in newAttrs) {
     newAttrs[attr] = undefined;
@@ -341,11 +337,10 @@ var text = function(value, var_args) {
     assertNotInAttributes();
   }
 
-  var node = alignWithDOM('#text', null);
-  var data = getData(node);
+  var node = alignWithDOM('#text');
 
-  if (data.text !== value) {
-    data.text = value;
+  if (node['__incrementalDOMText'] !== value) {
+    node['__incrementalDOMText'] = value;
 
     var formatted = value;
     for (var i = 1; i < arguments.length; i += 1) {

--- a/test/functional/conditional_rendering.js
+++ b/test/functional/conditional_rendering.js
@@ -53,7 +53,7 @@ describe('conditional rendering', () => {
       patch(container, () => render(false));
       var outer = container.childNodes[0];
 
-      expect(outer.childNodes.length).to.equal(2);
+      expect(outer.childNodes).to.have.length(2);
       expect(outer.childNodes[0].id).to.equal('one');
       expect(outer.childNodes[0].tagName).to.equal('DIV');
       expect(outer.childNodes[1].id).to.equal('two');
@@ -65,7 +65,7 @@ describe('conditional rendering', () => {
       patch(container, () => render(true));
       var outer = container.childNodes[0];
 
-      expect(outer.childNodes.length).to.equal(4);
+      expect(outer.childNodes).to.have.length(4);
       expect(outer.childNodes[0].id).to.equal('one');
       expect(outer.childNodes[0].tagName).to.equal('DIV');
       expect(outer.childNodes[1].id).to.equal('conditional-one');
@@ -94,7 +94,7 @@ describe('conditional rendering', () => {
       patch(container, () => render(false));
       var outer = container.childNodes[0];
 
-      expect(outer.childNodes.length).to.equal(0);
+      expect(outer.childNodes).to.have.length(0);
     });
   });
 
@@ -123,7 +123,7 @@ describe('conditional rendering', () => {
       patch(container, () => render(false));
       var outer = container.childNodes[0];
 
-      expect(outer.childNodes.length).to.equal(2);
+      expect(outer.childNodes).to.have.length(2);
       expect(outer.childNodes[0].id).to.equal('one');
       expect(outer.childNodes[0].tagName).to.equal('DIV');
       expect(outer.childNodes[1].id).to.equal('two');


### PR DESCRIPTION
Rather than using a NodeData object, simply keeping extra properties on the DOM node results in ~15% overall speed increase. This goes back to how I initially kept track of properties, but was changed to the current NodeData to structure things.This is rather unfortunate.

As a result of this change, the root node of a patch needs to have the whole subtree imported to handle server side rendered DOM.