### PR TITLE
Allow attribute hooks without exposing private workings

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,5 +25,24 @@ export {
   text,
   attr,
 } from './src/virtual_elements';
-export { attributes } from './src/attributes';
+
+
+import {
+  mutators as attrMutators,
+  defaults as attrDefaults
+} from './src/attributes';
+
+
+var mutators = {
+  attributes: attrMutators
+};
+
+var defaults = {
+  attributes: attrDefaults
+};
+
+export {
+  mutators,
+  defaults
+};
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2015 The Incremental DOM Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,15 +14,24 @@
  * limitations under the License.
  */
 
-export { patch } from './src/patch';
+import {
+  defaults as attributes
+} from './attributes';
+
+
+/**
+ * Publicly exports the default mutators from various internal modules.
+ * Note that mutating these objects will have no affect on the internal code,
+ * these are exposed only to be used by custom mutators.
+ * {Object<string, Object<string, function>>}
+ */
+var defaults = {
+  attributes: attributes
+};
+
+
+/** */
 export {
-  elementVoid,
-  elementOpenStart,
-  elementOpenEnd,
-  elementOpen,
-  elementClose,
-  text,
-  attr,
-} from './src/virtual_elements';
-export { mutators } from './src/mutators';
-export { defaults } from './src/defaults';
+  defaults
+};
+

--- a/src/mutators.js
+++ b/src/mutators.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2015 The Incremental DOM Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,15 +14,24 @@
  * limitations under the License.
  */
 
-export { patch } from './src/patch';
+import {
+  mutators as attributes,
+} from './attributes';
+
+
+/**
+ * Publicly exports the mutator hooks from various internal modules.
+ * Note that mutating these objects will alter the behavior of the internal
+ * code.
+ * {Object<string, Object<string, function>>}
+ */
+var mutators = {
+  attributes: attributes
+};
+
+
+/** */
 export {
-  elementVoid,
-  elementOpenStart,
-  elementOpenEnd,
-  elementOpen,
-  elementClose,
-  text,
-  attr,
-} from './src/virtual_elements';
-export { mutators } from './src/mutators';
-export { defaults } from './src/defaults';
+  mutators
+};
+

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { attributes } from './attributes';
+import { updateAttribute } from './attributes';
 import {
     getData,
     initData
@@ -49,7 +49,7 @@ var createElement = function(doc, tag, key, statics) {
 
   if (statics) {
     for (var i = 0; i < statics.length; i += 2) {
-      attributes.updateAttribute(el, statics[i], statics[i + 1]);
+      updateAttribute(el, statics[i], statics[i + 1]);
     }
   }
 

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -18,7 +18,7 @@ import {
   alignWithDOM,
   clearUnvisitedDOM
 } from './alignment';
-import { attributes } from './attributes';
+import { updateAttribute } from './attributes';
 import { getData } from './node_data';
 import { getWalker } from './walker';
 import {
@@ -154,7 +154,7 @@ var elementOpen = function(tag, key, statics, var_args) {
     }
 
     for (var attr in newAttrs) {
-      attributes.updateAttribute(node, attr, newAttrs[attr]);
+      updateAttribute(node, attr, newAttrs[attr]);
     }
   }
 

--- a/test/functional/hooks.js
+++ b/test/functional/hooks.js
@@ -17,13 +17,15 @@
 import {
     patch,
     elementVoid,
-    attributes
+    mutators
 } from '../../index';
 
 
 describe('library hooks', () => {
-  var container;
   var sandbox = sinon.sandbox.create();
+  var container;
+  var allSpy;
+  var stub;
 
   beforeEach(() => {
     container = document.createElement('div');
@@ -41,38 +43,120 @@ describe('library hooks', () => {
           'dynamicName', dynamicValue);
     }
 
+    function stubOut(mutator) {
+      stub = sandbox.stub();
+      mutators.attributes[mutator] = stub;
+    }
+
     beforeEach(() => {
-      sandbox.spy(attributes, 'applyAttr');
+      allSpy = sandbox.spy(mutators.attributes, '__all');
     });
 
-    it('should be called for static attributes', () => {
-      patch(container, render, 'dynamicValue');
-      var el = container.childNodes[0];
-
-      expect(attributes.applyAttr).calledWith(el, 'staticName', 'staticValue');
+    afterEach(() => {
+      for (var mutator in mutators.attributes) {
+        if (mutator !== '__all') {
+          mutators.attributes[mutator] = null;
+        }
+      }
     });
 
-    it('should be called for dynamic attributes', () => {
-      patch(container, render, 'dynamicValue');
-      var el = container.childNodes[0];
 
-      expect(attributes.applyAttr).calledWith(el, 'dynamicName', 'dynamicValue');
+    describe('for static attributes', () => {
+      it('should call specific setter', () => {
+        stubOut('staticName');
+
+        patch(container, render, 'dynamicValue');
+        var el = container.childNodes[0];
+
+        expect(stub).to.have.been.calledOnce;
+        expect(stub).to.have.been.calledWith(el, 'staticName', 'staticValue');
+      });
+
+      it('should call generic setter', () => {
+        patch(container, render, 'dynamicValue');
+        var el = container.childNodes[0];
+
+        expect(allSpy).to.have.been.calledWith(el, 'staticName', 'staticValue');
+      });
+
+      it('should prioritize specific setter over generic', () => {
+        stubOut('staticName');
+
+        patch(container, render, 'dynamicValue');
+        var el = container.childNodes[0];
+
+        expect(stub).to.have.been.calledOnce;
+        expect(allSpy).to.have.been.calledOnce;
+        expect(allSpy).to.have.been.calledWith(el, 'dynamicName', 'dynamicValue');
+      });
     });
 
-    it('should be called on attribute update', () => {
-      patch(container, render, 'dynamicValueOne');
-      patch(container, render, 'dynamicValueTwo');
-      var el = container.childNodes[0];
+    describe('for specific dynamic attributes', () => {
+      beforeEach(() => {
+        stubOut('dynamicName');
+      });
 
-      expect(attributes.applyAttr).calledWith(el, 'dynamicName', 'dynamicValueTwo');
+      it('should be called for dynamic attributes', () => {
+        patch(container, render, 'dynamicValue');
+        var el = container.childNodes[0];
+
+        expect(stub).to.have.been.calledOnce;
+        expect(stub).to.have.been.calledWith(el, 'dynamicName', 'dynamicValue');
+      });
+
+      it('should be called on attribute update', () => {
+        patch(container, render, 'dynamicValueOne');
+        patch(container, render, 'dynamicValueTwo');
+        var el = container.childNodes[0];
+
+        expect(stub).to.have.been.calledTwice;
+        expect(stub).to.have.been.calledWith(el, 'dynamicName', 'dynamicValueTwo');
+      });
+
+      it('should only be called when attributes change', () => {
+        patch(container, render, 'dynamicValue');
+        patch(container, render, 'dynamicValue');
+        var el = container.childNodes[0];
+
+        expect(stub).to.have.been.calledOnce;
+        expect(stub).to.have.been.calledWith(el, 'dynamicName', 'dynamicValue');
+      });
+
+      it('should prioritize specific setter over generic', () => {
+        patch(container, render, 'dynamicValue');
+        var el = container.childNodes[0];
+
+        expect(stub).to.have.been.calledOnce;
+        expect(allSpy).to.have.been.calledOnce;
+        expect(allSpy).to.have.been.calledWith(el, 'staticName', 'staticValue');
+      });
     });
 
-    it('should allow only be called when attributes change', () => {
-      patch(container, render, 'dynamicValue');
-      patch(container, render, 'dynamicValue');
+    describe('for generic dynamic attributes', () => {
+      it('should be called for dynamic attributes', () => {
+        patch(container, render, 'dynamicValue');
+        var el = container.childNodes[0];
 
-      // Called once for the static attribute and once for the dynamic one
-      expect(attributes.applyAttr).calledTwice;
+        expect(allSpy).to.have.been.calledWith(el, 'dynamicName', 'dynamicValue');
+      });
+
+      it('should be called on attribute update', () => {
+        patch(container, render, 'dynamicValueOne');
+        patch(container, render, 'dynamicValueTwo');
+        var el = container.childNodes[0];
+
+        expect(allSpy).to.have.been.calledWith(el, 'dynamicName', 'dynamicValueTwo');
+      });
+
+      it('should only be called when attributes change', () => {
+        patch(container, render, 'dynamicValue');
+        patch(container, render, 'dynamicValue');
+        var el = container.childNodes[0];
+
+        expect(allSpy).to.have.been.calledTwice;
+        expect(allSpy).to.have.been.calledWith(el, 'staticName', 'staticValue');
+        expect(allSpy).to.have.been.calledWith(el, 'dynamicName', 'dynamicValue');
+      });
     });
   });
 });

--- a/test/functional/hooks.js
+++ b/test/functional/hooks.js
@@ -44,7 +44,7 @@ describe('library hooks', () => {
     beforeEach(() => {
       sandbox.spy(attributes, 'applyAttr');
     });
-  
+
     it('should be called for static attributes', () => {
       patch(container, render, 'dynamicValue');
       var el = container.childNodes[0];


### PR DESCRIPTION
This is more thought out version of #72, providing both fine grained attribute setting as well as generic overrides. I prefer this style because it does not expose private workings publicly (`updateAttribute`
depends on `attributes.applyStyle`, etc).

I'm still publicly exposing our default mutators so they may be reused in any custom mutator, but mutating the `defaults` object will not cause any unintended side-effects (references are used, not object property lookups).

The main criticisms of #72 were, 1) filesize, 2) custom attributes. This aims to solve both.

1. No more giant list of attributes to apply as attributes. Defining the few property exceptions is much smaller.
  - 63 bytes increase after min-gzipping. If you verify, note that the current master does not include the `@license` comment in the build file while this build will. Removing that will produce a similar build at just 120bytes more.
2. We continue to use `typeof` to guess attributes or properties, and a special `__all__` mutator can be defined to provide generic overriding.