### PR TITLE
JS development build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -74,6 +74,8 @@ function bundle(format) {
 }
 
 function js(done) {
+  process.env.NODE_ENV = 'development';
+
   bundle('toUmd').then(function(gen) {
     file(artifactName + '.js', gen.code, {src: true})
       .pipe(sourcemaps.init({loadMaps: true}))

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/google/incremental-dom.git"
   },
-  "files" : [
+  "files": [
     "index.js",
     "src",
     "dist"


### PR DESCRIPTION
On the back of #88, let's bundle the un-minified JS into "development"
mode. We can't leave in the `process.env.NODE_ENV`, because browsers
don't have a `process` global.