### PR TITLE
Changing alignment to temporarliy remove misplaced key items.

### DIFF
--- a/src/node_data.js
+++ b/src/node_data.js
@@ -56,6 +56,12 @@ function NodeData(nodeName, key) {
   this.keyMap = null;
 
   /**
+   * Whether or not the keyMap is currently valid.
+   * {boolean}
+   */
+  this.keyMapValid = true;
+
+  /**
    * The last child to have been visited within the current pass.
    * {?Node}
    */


### PR DESCRIPTION
When the current node is a keyed item, remove it from the DOM instead of just moving the matching node before it. The node will be added back using it's entry in the key mapping if necessary. This reduces the number of move operations needed from O(n) to O(number of moves) when items are keyed. As a result, performance when keyed nodes are moved/removed from the start of a parent is greatly improved.

@cramforce 