### PR TITLE
Added basic support for node create/remove notfication callbacks

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2015 The Incremental DOM Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,17 +14,25 @@
  * limitations under the License.
  */
 
-export { patch } from './src/patch';
+/**
+ */
+var notifications = {
+  /**
+   * Called after patch has compleated with any Nodes that have been created
+   * and added to the DOM.
+   * @type {?function(Array.<!Node>)}
+   */
+  nodesCreated: null,
+
+  /**
+   * Called after patch has compleated with any Nodes that have been removed
+   * from the DOM.
+   * Note it's an applications responsibility to handle any childNodes.
+   * @type {?function(Array.<!Node>)}
+   */
+  nodesDeleted: null
+};
+
 export {
-  elementVoid,
-  elementOpenStart,
-  elementOpenEnd,
-  elementOpen,
-  elementClose,
-  text,
-  attr,
-} from './src/virtual_elements';
-export { symbols } from './src/symbols';
-export { mutators } from './src/mutators';
-export { defaults } from './src/defaults';
-export { notifications } from './src/notifications';
+  notifications
+};

--- a/src/patch.js
+++ b/src/patch.js
@@ -61,7 +61,8 @@ if (process.env.NODE_ENV !== 'production') {
  */
 var patch = function(node, fn, data) {
   var prevWalker = getWalker();
-  setWalker(new TreeWalker(node));
+  var walker = new TreeWalker(node);
+  setWalker(walker);
 
   firstChild();
   fn(data);
@@ -71,6 +72,8 @@ var patch = function(node, fn, data) {
   if (process.env.NODE_ENV !== 'production') {
     assertNoUnclosedTags(node);
   }
+
+  walker.notifyChanges();
 
   setWalker(prevWalker);
 };

--- a/src/tree_walker.js
+++ b/src/tree_walker.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { notifications } from './notifications';
+
 /**
  * Similar to the built-in Treewalker class, but simplified and allows direct
  * access to modify the currentNode property.
@@ -46,6 +48,16 @@ function TreeWalker(node) {
    * @const {!Array<(string|undefined)>}
    */
   this.nsStack_ = [undefined];
+
+  /**
+   * @type {(Array<!Node>|undefined)}
+   */
+  this.created = notifications.nodesCreated && [];
+
+  /**
+   * @type {(Array<!Node>|undefined)}
+   */
+  this.deleted = notifications.nodesDeleted && [];
 }
 
 
@@ -103,6 +115,18 @@ TreeWalker.prototype.nextSibling = function() {
  */
 TreeWalker.prototype.parentNode = function() {
   this.currentNode = this.stack_.pop();
+};
+
+/**
+ *
+ */
+TreeWalker.prototype.notifyChanges = function() {
+  if (this.created && this.created.length > 0) {
+    notifications.nodesCreated(this.created);
+  }
+  if (this.deleted && this.deleted.length > 0) {
+    notifications.nodesDeleted(this.deleted);
+  }
 };
 
 

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -294,7 +294,7 @@ var text = function(value, var_args) {
     assertNotInAttributes();
   }
 
-  var node = alignWithDOM('#text', null);
+  var node = /** @type {!Text}*/(alignWithDOM('#text', null));
   var data = getData(node);
 
   if (data.text !== value) {

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -294,7 +294,7 @@ var text = function(value, var_args) {
     assertNotInAttributes();
   }
 
-  var node = /** @type {!Text}*/(alignWithDOM('#text', null));
+  var node = alignWithDOM('#text', null);
   var data = getData(node);
 
   if (data.text !== value) {


### PR DESCRIPTION
An updated version of #105 which should add support for notifications on node creation and removal. Few things to note:
* Intentionally not called events so as not to confuse with `EventTarget.addEventListener` style handling, also not included with `mutators` as they are not mutating anything. Maybe `mutators` should be refactored to hooks and combine the two?
* If not overriden the default callbacks should get optimized away as they are noops
* I have left `updatedNode` notifications for now
* Callbacks are only passed `node` as first argument and dont change behaviour to make it easier to extend their behavour later 

I also left off `translateIntoNodeName` for another pull request as I think the changes might be invasive (and I personally am not sure its the best way to go).