### PR TITLE
Avoid Map prototype collisions

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -16,6 +16,10 @@
 
 import { getData } from './node_data';
 import { symbols } from './symbols';
+import {
+  createMap,
+  has
+} from './util';
 
 
 /**
@@ -58,9 +62,12 @@ var applyStyle = function(el, name, style) {
     el.style.cssText = style;
   } else {
     el.style.cssText = '';
+    var elStyle = el.style;
 
     for (var prop in style) {
-      el.style[prop] = style[prop];
+      if (has(style, prop)) {
+        elStyle[prop] = style[prop];
+      }
     }
   }
 };
@@ -110,16 +117,15 @@ var updateAttribute = function(el, name, value) {
  * A publicly mutable object to provide custom mutators for attributes.
  * @const {!Object<string, function(!Element, string, *)>}
  */
-var attributes = {
-  // Special generic mutator that's called for any attribute that does not
-  // have a specific mutator.
-  [symbols.all]: applyAttributeTyped,
+var attributes = createMap();
 
-  [symbols.placeholder]: function() {},
+// Special generic mutator that's called for any attribute that does not
+// have a specific mutator.
+attributes[symbols.all] = applyAttributeTyped;
 
-  // Special case the style attribute
-  style: applyStyle
-};
+attributes[symbols.placeholder] = function() {};
+
+attributes['style'] = applyStyle;
 
 
 /** */

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { createMap } from './util';
+
 
 /**
  * Keeps track of information needed to perform diffs for a given DOM node.
@@ -26,7 +28,7 @@ function NodeData(nodeName, key) {
    * The attributes and their values.
    * @const
    */
-  this.attrs = {};
+  this.attrs = createMap();
 
   /**
    * An array of attribute name/value pairs, used for quickly diffing the
@@ -40,7 +42,7 @@ function NodeData(nodeName, key) {
    * The incoming attributes for this Node, before they are updated.
    * @const {!Object<string, *>}
    */
-  this.newAttrs = {};
+  this.newAttrs = createMap();
 
   /**
    * The key used to identify this node, used to preserve DOM nodes when they

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -20,6 +20,7 @@ import {
     initData
 } from './node_data';
 import { getNamespaceForTag } from './namespace';
+import { createMap } from './util';
 
 
 // For https://github.com/esperantojs/esperanto/issues/187
@@ -85,7 +86,7 @@ var createNode = function(doc, nodeName, key, statics) {
  *     Element.
  */
 var createKeyMap = function(el) {
-  var map = {};
+  var map = createMap();
   var children = el.children;
   var count = children.length;
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2015 The Incremental DOM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * A cached reference to the hasOwnProperty function.
+ */
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
+
+/**
+ * A cached reference to the create function.
+ */
+var create = Object.create;
+
+
+/**
+ * Used to prevent property collisions between our "map" and its prototype.
+ * @param {!Object<string, *>} map The map to check.
+ * @param {string} property The property to check.
+ * @return {boolean} Whether map has property.
+ */
+var has = function(map, property) {
+  return hasOwnProperty.call(map, property);
+};
+
+
+/**
+ * Creates an map object without a prototype.
+ * @return {!Object}
+ */
+var createMap = function() {
+  return create(null);
+};
+
+
+/** */
+export {
+  createMap,
+  has
+};
+

--- a/test/functional/keyed_items.js
+++ b/test/functional/keyed_items.js
@@ -135,5 +135,14 @@ describe('rendering with keys', () => {
     expect(container.childNodes[2]).to.equal(secondNode);
     expect(container.childNodes[2].id).to.equal('two');
   });
+
+  it('should avoid collisions with Object.prototype', () => {
+    var items = [
+      { key: 'hasOwnProperty' }
+    ];
+
+    patch(container, () => render(items));
+    expect(container.childNodes).to.have.length(1);
+  });
 });
 


### PR DESCRIPTION
On the topic of `isValid` key, we're susceptible to the well-known `Object.prototype` properties as well as any user defined ones.