### PR TITLE
Relaxed some of the closure types

### DIFF
--- a/src/alignment.js
+++ b/src/alignment.js
@@ -82,7 +82,7 @@ var alignWithDOM = function(nodeName, key, statics) {
   if (currentNode && matches(currentNode, nodeName, key)) {
     matchingNode = currentNode;
   } else {
-    var existingNode = /** @type {Element} */(getChild(parent, key));
+    var existingNode = getChild(parent, key);
 
     // Check to see if the node has moved within the parent or if a new one
     // should be created
@@ -121,7 +121,7 @@ var alignWithDOM = function(nodeName, key, statics) {
 /**
  * Clears out any unvisited Nodes, as the corresponding virtual element
  * functions were never called for them.
- * @param {!Node} node
+ * @param {Node} node
  */
 var clearUnvisitedDOM = function(node) {
   var data = getData(node);

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -83,7 +83,7 @@ function NodeData(nodeName, key) {
 /**
  * Initializes a NodeData object for a Node.
  *
- * @param {!Node} node The node to initialize data for.
+ * @param {Node} node The node to initialize data for.
  * @param {string} nodeName The node name of node.
  * @param {?string=} key The key that identifies the node.
  * @return {!NodeData} The newly initialized data object
@@ -98,8 +98,8 @@ var initData = function(node, nodeName, key) {
 /**
  * Retrieves the NodeData object for a Node, creating it if necessary.
  *
- * @param {!Node} node The node to retrieve the data for.
- * @return {NodeData} The NodeData for this Node.
+ * @param {Node} node The node to retrieve the data for.
+ * @return {!NodeData} The NodeData for this Node.
  */
 var getData = function(node) {
   var data = node['__incrementalDOMData'];

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -28,7 +28,7 @@ var dummy;
 
 /**
  * Creates an Element.
- * @param {!Document} doc The document with which to create the Element.
+ * @param {Document} doc The document with which to create the Element.
  * @param {string} tag The tag for the Element.
  * @param {?string=} key A key to identify the Element.
  * @param {?Array<*>=} statics An array of attribute name/value pairs of
@@ -60,7 +60,7 @@ var createElement = function(doc, tag, key, statics) {
 /**
  * Creates a Node, either a Text or an Element depending on the node name
  * provided.
- * @param {!Document} doc The document with which to create the Node.
+ * @param {Document} doc The document with which to create the Node.
  * @param {string} nodeName The tag if creating an element or #text to create
  *     a Text.
  * @param {?string=} key A key to identify the Element.

--- a/src/traversal.js
+++ b/src/traversal.js
@@ -28,7 +28,7 @@ var dummy;
 
 /**
  * Enters an Element, setting the current namespace for nested elements.
- * @param {!Node} node
+ * @param {Node} node
  */
 var enterNode = function(node) {
   var data = getData(node);
@@ -38,7 +38,7 @@ var enterNode = function(node) {
 
 /**
  * Exits an Element, unwinding the current namespace to the previous value.
- * @param {!Node} node
+ * @param {Node} node
  */
 var exitNode = function(node) {
   var data = getData(node);
@@ -48,7 +48,7 @@ var exitNode = function(node) {
 
 /**
  * Marks node's parent as having visited node.
- * @param {!Node} node
+ * @param {Node} node
  */
 var markVisited = function(node) {
   var walker = getWalker();
@@ -63,7 +63,7 @@ var markVisited = function(node) {
  */
 var firstChild = function() {
   var walker = getWalker();
-  enterNode(/** @type {!Node}*/(walker.currentNode));
+  enterNode(walker.currentNode);
   walker.firstChild();
 };
 
@@ -73,7 +73,7 @@ var firstChild = function() {
  */
 var nextSibling = function() {
   var walker = getWalker();
-  markVisited(/** @type {!Node}*/(walker.currentNode));
+  markVisited(walker.currentNode);
   walker.nextSibling();
 };
 
@@ -84,7 +84,7 @@ var nextSibling = function() {
 var parentNode = function() {
   var walker = getWalker();
   walker.parentNode();
-  exitNode(/** @type {!Node}*/(walker.currentNode));
+  exitNode(walker.currentNode);
 };
 
 

--- a/src/tree_walker.js
+++ b/src/tree_walker.js
@@ -36,7 +36,7 @@ function TreeWalker(node) {
   this.currentNode = node;
 
   /**
-   * @const {!Document}
+   * @const {Document}
    */
   this.doc = node.ownerDocument;
 

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -285,7 +285,7 @@ var elementVoid = function(tag, key, statics, var_args) {
  * Declares a virtual Text at this point in the document.
  *
  * @param {string|number|boolean} value The value of the Text.
- * @param {...(function(string|number|boolean):string)} var_args
+ * @param {...function((string|number|boolean)):string} var_args
  *     Functions to format the value which are called only when the value has
  *     changed.
  * @return {!Text} The corresponding text node.

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -285,7 +285,7 @@ var elementVoid = function(tag, key, statics, var_args) {
  * Declares a virtual Text at this point in the document.
  *
  * @param {string|number|boolean} value The value of the Text.
- * @param {...function((string|number|boolean)):string} var_args
+ * @param {...(function((string|number|boolean)):string)} var_args
  *     Functions to format the value which are called only when the value has
  *     changed.
  * @return {!Text} The corresponding text node.


### PR DESCRIPTION
By relaxing some of the typing info you can still compile without warnings and remove some inline `/** @type {...}*/(...)` at the same time.

Goes part of the way to addressing issues with #112