### PR TITLE
Attribute maps

### DIFF
--- a/src/alignment.js
+++ b/src/alignment.js
@@ -68,8 +68,8 @@ var matches = function(node, nodeName, key) {
  * @param {string} nodeName For an Element, this should be a valid tag string.
  *     For a Text, this should be #text.
  * @param {?string=} key The key used to identify this element.
- * @param {?Array<*>=} statics For an Element, this should be an array of
- *     name-value pairs.
+ * @param {?Object<string, *>=} statics For an Element, this should be an object
+ *     of name-value pairs.
  * @return {!Node} The matching node.
  */
 var alignWithDOM = function(nodeName, key, statics) {

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -88,20 +88,40 @@ var applyAttributeTyped = function(el, name, value) {
  * Calls the appropriate attribute mutator for this attribute.
  * @param {!Element} el
  * @param {string} name The attribute's name.
- * @param {*} value The attribute's value.
+ * @param {*=} value The attribute's value.
  */
 var updateAttribute = function(el, name, value) {
-  var data = getData(el);
-  var attrs = data.attrs;
-
-  if (attrs[name] === value) {
-    return;
-  }
-
   var mutator = mutators[name] || mutators.__all;
   mutator(el, name, value);
+};
 
-  attrs[name] = value;
+
+/**
+ * Mirrors the attributes on an Element to the passed in attributes.
+ * @param {!Element} el
+ * @param {?Object<string, *>=} attributes An object of attribute name/value
+ *     pairs of the dynamic attributes for the Element.
+ */
+var updateAttributes = function(el, attributes) {
+  var data = getData(el);
+  var attrs = data.attrs;
+  var attr;
+
+  for (attr in attrs) {
+    if (!(attributes && attr in attributes)) {
+      updateAttribute(el, attr);
+      delete attrs[attr];
+    }
+  }
+
+  for (attr in attributes) {
+    var value = attributes[attr];
+
+    if (attrs[attr] !== value) {
+      updateAttribute(el, attr, value);
+      attrs[attr] = value;
+    }
+  }
 };
 
 
@@ -133,6 +153,7 @@ var mutators = {
 
 /** */
 export {
+  updateAttributes,
   updateAttribute,
   defaults,
   mutators

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -24,40 +24,26 @@
 function NodeData(nodeName, key) {
   /**
    * The attributes and their values.
-   * @const
+   * @const {!Object<string, *>}
    */
   this.attrs = {};
 
   /**
-   * An array of attribute name/value pairs, used for quickly diffing the
-   * incomming attributes to see if the DOM node's attributes need to be
-   * updated.
-   * @const {Array<*>}
-   */
-  this.attrsArr = [];
-
-  /**
-   * The incoming attributes for this Node, before they are updated.
-   * @const {!Object<string, *>}
-   */
-  this.newAttrs = {};
-
-  /**
    * The key used to identify this node, used to preserve DOM nodes when they
    * move within their parent.
-   * @const
+   * @const {?string}
    */
   this.key = key;
 
   /**
    * Keeps track of children within this node by their key.
-   * {?Object<string, !Element>}
+   * @type {?Object<string, !Element>}
    */
   this.keyMap = null;
 
   /**
    * Whether or not the keyMap is currently valid.
-   * {boolean}
+   * @type {boolean}
    */
   this.keyMapValid = true;
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -31,8 +31,8 @@ var dummy;
  * @param {!Document} doc The document with which to create the Element.
  * @param {string} tag The tag for the Element.
  * @param {?string=} key A key to identify the Element.
- * @param {?Array<*>=} statics An array of attribute name/value pairs of
- *     the static attributes for the Element.
+ * @param {?Object<string, *>=} statics An object of attribute name/value pairs
+ *     of the static attributes for the Element.
  * @return {!Element}
  */
 var createElement = function(doc, tag, key, statics) {
@@ -47,10 +47,8 @@ var createElement = function(doc, tag, key, statics) {
 
   initData(el, tag, key);
 
-  if (statics) {
-    for (var i = 0; i < statics.length; i += 2) {
-      updateAttribute(el, /** @type {!string}*/(statics[i]), statics[i + 1]);
-    }
+  for (var attr in statics) {
+    updateAttribute(el, attr, statics[attr]);
   }
 
   return el;
@@ -64,9 +62,8 @@ var createElement = function(doc, tag, key, statics) {
  * @param {string} nodeName The tag if creating an element or #text to create
  *     a Text.
  * @param {?string=} key A key to identify the Element.
- * @param {?Array<*>=} statics The static data to initialize the Node
- *     with. For an Element, an array of attribute name/value pairs of
- *     the static attributes for the Element.
+ * @param {?Object<string, *>=} statics For an Element, an object of attribute
+ *     name/value pairs of the static attributes for the Element.
  * @return {!Node}
  */
 var createNode = function(doc, nodeName, key, statics) {

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -37,7 +37,7 @@ describe('attribute updates', () => {
 
   describe('for conditional attributes', () => {
     function render(attrs) {
-      elementOpenStart('div', '', []);
+      elementOpenStart('div', '', {});
       for (var attrName in attrs) {
           attr(attrName, attrs[attrName]);
       }
@@ -118,8 +118,7 @@ describe('attribute updates', () => {
     it('should not be set as attributes', () => {
       var fn = () =>{};
       patch(container, () => {
-        elementVoid('div', '', null,
-            'fn', fn);
+        elementVoid('div', null, null, {fn: fn});
       });
       var el = container.childNodes[0];
 
@@ -129,8 +128,7 @@ describe('attribute updates', () => {
     it('should be set on the node', () => {
       var fn = () =>{};
       patch(container, () => {
-        elementVoid('div', '', null,
-            'fn', fn);
+        elementVoid('div', null, null, {fn: fn});
       });
       var el = container.childNodes[0];
 
@@ -142,8 +140,7 @@ describe('attribute updates', () => {
     it('should not be set as attributes', () => {
       var obj = {};
       patch(container, () => {
-        elementVoid('div', '', null,
-            'obj', obj);
+        elementVoid('div', null, null, {obj: obj});
       });
       var el = container.childNodes[0];
 
@@ -153,8 +150,7 @@ describe('attribute updates', () => {
     it('should be set on the node', () => {
       var obj = {};
       patch(container, () => {
-        elementVoid('div', '', null,
-            'obj', obj);
+        elementVoid('div', null, null, {obj: obj});
       });
       var el = container.childNodes[0];
 
@@ -164,8 +160,7 @@ describe('attribute updates', () => {
 
   describe('for style', () => {
     function render(style) {
-      elementVoid('div', '', [],
-          'style', style);
+      elementVoid('div', null, null, {style: style});
     }
 
     it('should render with the correct style properties for objects', () => {
@@ -216,8 +211,7 @@ describe('attribute updates', () => {
   describe('for svg elements', () => {
     it('should correctly apply the class attribute', function() {
       patch(container, () => {
-        elementVoid('svg', null, null,
-            'class', 'foo');
+        elementVoid('svg', null, null, {class: 'foo'});
       });
       var el = container.childNodes[0];
 

--- a/test/functional/conditional_rendering.js
+++ b/test/functional/conditional_rendering.js
@@ -36,15 +36,15 @@ describe('conditional rendering', () => {
 
   describe('nodes', () => {
     function render(condition) {
-      elementOpen('div', '', ['id', 'outer']);
-        elementVoid('div', '', ['id', 'one']);
+      elementOpen('div', null, {id: 'outer'});
+        elementVoid('div', null, {id: 'one'});
 
         if (condition) {
-          elementVoid('div', '', ['id', 'conditional-one']);
-          elementVoid('div', '', ['id', 'conditional-two']);
+          elementVoid('div', null, {id: 'conditional-one'});
+          elementVoid('div', null, {id: 'conditional-two'});
         }
 
-        elementVoid('span', '', ['id', 'two' ]);
+        elementVoid('span', null, {id: 'two' });
       elementClose('div');
     }
 
@@ -79,11 +79,11 @@ describe('conditional rendering', () => {
 
   describe('with only conditional childNodes', () => {
     function render(condition) {
-      elementOpen('div', '', ['id', 'outer']);
+      elementOpen('div', null, {id: 'outer'});
 
         if (condition) {
-          elementVoid('div', '', ['id', 'conditional-one' ]);
-          elementVoid('div', '', ['id', 'conditional-two' ]);
+          elementVoid('div', null, {id: 'conditional-one'});
+          elementVoid('div', null, {id: 'conditional-two'});
         }
 
       elementClose('div');
@@ -100,21 +100,16 @@ describe('conditional rendering', () => {
 
   describe('nodes', () => {
     function render(condition) {
-      elementOpen('div', '', [],
-          'id', 'outer');
-        elementVoid('div', '', [],
-            'id', 'one' );
+      elementOpen('div', null, null, {id: 'outer'});
+        elementVoid('div', null, null, {id: 'one'});
 
         if (condition) {
-          elementOpen('span', '', [],
-              'id', 'conditional-one',
-              'data-foo', 'foo');
-            elementVoid('span', '', []);
+          elementOpen('span', null, null, {id: 'conditional-one', 'data-foo': 'foo'});
+            elementVoid('span', null, null);
           elementClose('span');
         }
 
-        elementVoid('span', '', [],
-            'id', 'two');
+        elementVoid('span', null, null, {id: 'two'});
       elementClose('div');
     }
 

--- a/test/functional/element_creation.js
+++ b/test/functional/element_creation.js
@@ -42,9 +42,14 @@ describe('element creation', () => {
 
     beforeEach(() => {
       patch(container, () => {
-        elementVoid('div', '', ['id', 'someId', 'class', 'someClass', 'data-custom', 'custom'],
-            'data-foo', 'Hello',
-            'data-bar', 'World');
+        elementVoid('div', null, {
+          'id': 'someId',
+          'class': 'someClass',
+          'data-custom': 'custom'
+        }, {
+          'data-foo': 'Hello',
+          'data-bar': 'World'
+        });
       });
 
       el = container.childNodes[0];
@@ -111,8 +116,7 @@ describe('element creation', () => {
 
   it('should allow creation without static attributes', () => {
     patch(container, () => {
-      elementVoid('div', '', null,
-          'id', 'test');
+      elementVoid('div', null, null, {id: 'test'});
     });
     var el = container.childNodes[0];
     expect(el.id).to.equal('test');

--- a/test/functional/hooks.js
+++ b/test/functional/hooks.js
@@ -39,8 +39,7 @@ describe('library hooks', () => {
 
   describe('for deciding how attributes are set', () => {
     function render(dynamicValue) {
-      elementVoid('div', null, ['staticName', 'staticValue'],
-          'dynamicName', dynamicValue);
+      elementVoid('div', null, {staticName: 'staticValue'}, {dynamicName: dynamicValue});
     }
 
     function stubOut(mutator) {

--- a/test/functional/keyed_items.js
+++ b/test/functional/keyed_items.js
@@ -25,7 +25,7 @@ describe('rendering with keys', () => {
 
   function render(items) {
     for(var i=0; i<items.length; i++) {
-      elementVoid('div', items[i].key, ['id', items[i].key]);
+      elementVoid('div', items[i].key, {id: items[i].key});
     }
   }
 

--- a/test/functional/patch.js
+++ b/test/functional/patch.js
@@ -41,8 +41,7 @@ describe('patching an element', () => {
     var div;
 
     function render() {
-      elementVoid('div', null, null,
-          'tabindex', '0');
+      elementVoid('div', null, null, {tabindex: '0'});
     }
 
     beforeEach(function() {
@@ -143,8 +142,7 @@ describe('patching a documentFragment', function() {
     var frag = document.createDocumentFragment();
 
     patch(frag, function() {
-      elementOpen('div', null, null,
-          'id', 'aDiv');
+      elementOpen('div', null, null, {id: 'aDiv'});
       elementClose('div');
     });
 

--- a/test/functional/virtual_attributes.js
+++ b/test/functional/virtual_attributes.js
@@ -37,8 +37,8 @@ describe('virtual attribute updates', () => {
   });
 
   describe('for conditional attributes', () => {
-    function render(obj) {  
-      elementOpenStart('div', '', []);
+    function render(obj) {
+      elementOpenStart('div');
         if (obj.key) {
           attr('data-expanded', obj.key);
         }


### PR DESCRIPTION
Following the discussion in https://github.com/google/incremental-dom/issues/114, here's iDOM reworked to accept a map of attribute name/values.

Fixes https://github.com/google/incremental-dom/issues/115, https://github.com/google/incremental-dom/issues/23. It also opens up the possibility of exposing `updateAttributes` publicly, allowing [Glimmer-like](https://github.com/babel-plugins/babel-plugin-incremental-dom/issues/11) rendering without patching everything in the containing element.

I'd love some outside performance testing. I'm showing an improvement over master, even with the object allocations.