### PR TITLE
Support IE8 TextNode

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -16,6 +16,7 @@
 
 import { TreeWalker } from './tree_walker';
 import { notifications } from './notifications';
+import { testLegacyTextSupport } from './legacy_support';
 
 
 /**
@@ -57,6 +58,11 @@ function Context(node, prevContext) {
    * @type {(Array<!Node>|undefined)}
    */
   this.deleted = notifications.nodesDeleted && [];
+
+  /**
+   * @const {boolean}
+   */
+  this.legacyTextSupport = testLegacyTextSupport(this.doc);
 }
 
 

--- a/src/legacy_support.js
+++ b/src/legacy_support.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015 The Incremental DOM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Whether the current environment needs legacy text support
+ *
+ * @type {boolean}
+ */
+var legacyTextSupport;
+
+
+/**
+ * Tests whether the current environment needs legacy text support.
+ * @param {Document} doc A Document to create a TextNode.
+ */
+var testLegacyTextSupport = function(doc) {
+  if (legacyTextSupport === undefined) {
+    var text = doc.createTextNode('');
+
+    try {
+      text['__incrementalDOMData'] = text;
+      legacyTextSupport = false;
+    } catch (e) {
+      legacyTextSupport = true;
+    }
+  }
+  return legacyTextSupport;
+};
+
+
+/** */
+export {
+  testLegacyTextSupport
+};

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -301,7 +301,7 @@ var text = function(value, var_args) {
   var data = getData(node);
 
   if (data.text !== value) {
-    data.text = /** @type {string} */(value);
+    data.text = value;
 
     var formatted = value;
     for (var i = 1; i < arguments.length; i += 1) {


### PR DESCRIPTION
Supports `text` in IE8, fixes https://github.com/google/incremental-dom/issues/69#issuecomment-133910391.

The old code tried setting `node.__incrementalDOMData = new NodeData()`, which will throw for TextNodes. The new code will detect the legacy environment, and never set. Unfortunately, it means that we can't cache the `TextData` object (so we'll recreate it every patch).