### PR TITLE
Cleanups

### DIFF
--- a/src/alignment.js
+++ b/src/alignment.js
@@ -128,41 +128,32 @@ var clearUnvisitedDOM = function(node) {
   var walker = context.walker;
   var data = getData(node);
   var keyMap = data.keyMap;
-  var keyMapValid = data.keyMapValid;
   var lastVisitedChild = data.lastVisitedChild;
-  var child = node.lastChild;
-  var key;
+  var lastChild = node.lastChild;
 
-  data.lastVisitedChild = null;
-
-  if (child === lastVisitedChild && keyMapValid) {
+  if (data.attrs[symbols.placeholder] && node !== walker.root) {
     return;
-  }
-
-  if (data.attrs[symbols.placeholder] && walker.currentNode !== walker.root) {
-    return;
-  }
-
-  while (child !== lastVisitedChild) {
-    node.removeChild(child);
-    context.markDeleted(/** @type {!Node}*/(child));
-
-    key = getData(child).key;
-    if (key) {
-      delete keyMap[key];
-    }
-    child = node.lastChild;
   }
 
   // Clean the keyMap, removing any unusued keys.
-  for (key in keyMap) {
-    child = keyMap[key];
-    if (!child.parentNode) {
-      context.markDeleted(child);
-      delete keyMap[key];
+  if (!data.keyMapValid) {
+    for (var key in keyMap) {
+      var child = keyMap[key];
+      if (child.parentNode !== node) {
+        context.markDeleted(child);
+        delete keyMap[key];
+      }
     }
   }
 
+  while (lastChild !== lastVisitedChild) {
+    node.removeChild(lastChild);
+    context.markDeleted(/** @type {!Node} **/(lastChild));
+
+    lastChild = node.lastChild;
+  }
+
+  data.lastVisitedChild = null;
   data.keyMapValid = true;
 };
 

--- a/src/alignment.js
+++ b/src/alignment.js
@@ -80,21 +80,21 @@ var alignWithDOM = function(nodeName, key, statics) {
   if (currentNode && matches(currentNode, nodeName, key)) {
     matchingNode = currentNode;
   } else {
-    var existingNode = getChild(parent, key);
+    if (key) {
+      matchingNode = getChild(parent, key);
+    }
 
     // Check to see if the node has moved within the parent or if a new one
     // should be created
-    if (existingNode) {
+    if (matchingNode) {
       if (process.env.NODE_ENV !== 'production') {
-        assertKeyedTagMatches(existingNode, nodeName, key);
+        assertKeyedTagMatches(matchingNode, nodeName, key);
       }
-
-      matchingNode = existingNode;
     } else {
       matchingNode = createNode(context.doc, nodeName, key, statics);
 
       if (key) {
-        registerChild(parent, key, matchingNode);
+        registerChild(parent, key, /** @type {!Element} **/(matchingNode));
       }
 
       context.markCreated(matchingNode);

--- a/src/context.js
+++ b/src/context.js
@@ -42,12 +42,12 @@ function Context(node, prevContext) {
   this.prevContext = prevContext;
 
   /**
-   * @type {(Array<!Node>|undefined)}
+   * @type {?Array<!Node>}
    */
   this.created = notifications.nodesCreated && [];
 
   /**
-   * @type {(Array<!Node>|undefined)}
+   * @type {?Array<!Node>}
    */
   this.deleted = notifications.nodesDeleted && [];
 }

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -76,7 +76,7 @@ function NodeData(nodeName, key) {
   this.nodeName = nodeName;
 
   /**
-   * @type {?string}
+   * @type {?(string|number|boolean)}
    */
   this.text = null;
 }

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -103,7 +103,7 @@ var createKeyMap = function(el) {
  * Retrieves the mapping of key to child node for a given Element, creating it
  * if necessary.
  * @param {!Node} el
- * @return {!Object<string, !Node>} A mapping of keys to child Elements
+ * @return {!Object<string, !Element>} A mapping of keys to child Elements
  */
 var getKeyMap = function(el) {
   var data = getData(el);
@@ -119,11 +119,12 @@ var getKeyMap = function(el) {
 /**
  * Retrieves a child from the parent with the given key.
  * @param {!Node} parent
- * @param {?string=} key
+ * @param {string} key
  * @return {?Element} The child corresponding to the key.
  */
 var getChild = function(parent, key) {
-  return /** @type {?Element} */(key && getKeyMap(parent)[key]);
+  var child = getKeyMap(parent)[key];
+  return child || null;
 };
 
 
@@ -133,7 +134,7 @@ var getChild = function(parent, key) {
  * getKeyMap. The provided key should be unique within the parent Element.
  * @param {!Node} parent The parent of child.
  * @param {string} key A key to identify the child with.
- * @param {!Node} child The child to register.
+ * @param {!Element} child The child to register.
  */
 var registerChild = function(parent, key, child) {
   getKeyMap(parent)[key] = child;

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -332,7 +332,7 @@ var text = function(value, var_args) {
   var data = getData(node);
 
   if (data.text !== value) {
-    data.text = /** @type {string} */(value);
+    data.text = value;
 
     var formatted = value;
     for (var i = 1; i < arguments.length; i += 1) {

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -143,6 +143,7 @@ var elementOpen = function(tag, key, statics, var_args) {
    * minimal.
    */
   var attrsArr = data.attrsArr;
+  var newAttrs = data.newAttrs;
   var attrsChanged = false;
   var i = ATTRIBUTES_OFFSET;
   var j = 0;
@@ -167,18 +168,13 @@ var elementOpen = function(tag, key, statics, var_args) {
    * Actually perform the attribute update.
    */
   if (attrsChanged) {
-    var attr, newAttrs = data.newAttrs;
-
-    for (attr in newAttrs) {
-      newAttrs[attr] = undefined;
-    }
-
     for (i = ATTRIBUTES_OFFSET; i < arguments.length; i += 2) {
       newAttrs[arguments[i]] = arguments[i + 1];
     }
 
-    for (attr in newAttrs) {
+    for (var attr in newAttrs) {
       updateAttribute(node, attr, newAttrs[attr]);
+      newAttrs[attr] = undefined;
     }
   }
 

--- a/test/functional/placeholders.js
+++ b/test/functional/placeholders.js
@@ -15,11 +15,11 @@
  */
 
 import {
-    patch,
-    elementVoid,
-    elementPlaceholder,
-    text,
-    symbols
+  patch,
+  elementVoid,
+  elementPlaceholder,
+  text,
+  symbols
 } from '../../index';
 
 
@@ -51,7 +51,7 @@ describe('placeholders', () => {
       var child = document.createElement('div');
 
       patch(container, render, { key: 'key' });
-      var el = container.firstChild;      
+      var el = container.firstChild;
       el.appendChild(child);
       patch(container, render, { key: 'key' });
 
@@ -66,9 +66,9 @@ describe('placeholders', () => {
           elementVoid('p');
         }
       }
-  
+
       patch(container, render, { key: 'key' });
-      var el = container.firstChild;      
+      var el = container.firstChild;
       patch(el, innerRender, true);
       patch(el, innerRender, false);
 
@@ -79,7 +79,7 @@ describe('placeholders', () => {
   describe('created with elementPlaceholder', () => {
     function render(data) {
       elementPlaceholder('div', data.key, ['staticName', 'staticValue'],
-          'dynamicName', data.val);
+                         'dynamicName', data.val);
     }
 
     it('should warn about a missing key', () => {
@@ -89,7 +89,7 @@ describe('placeholders', () => {
 
     it('should render with specified static attributes', () => {
       patch(container, render, { key: 'key' });
-      var el = container.firstChild;      
+      var el = container.firstChild;
 
       expect(el.getAttribute('staticName')).to.equal('staticValue');
     });
@@ -99,14 +99,14 @@ describe('placeholders', () => {
         key: 'key',
         val: 'dynamicValue'
       });
-      var el = container.firstChild;      
+      var el = container.firstChild;
 
       expect(el.getAttribute('dynamicName')).to.equal('dynamicValue');
     });
 
     it('should reuse the same node', () => {
       patch(container, render, { key: 'key' });
-      var el = container.firstChild;      
+      var el = container.firstChild;
       patch(container, render, { key: 'key' });
 
       expect(container.firstChild).to.equal(el);
@@ -116,7 +116,7 @@ describe('placeholders', () => {
       var child = document.createElement('div');
 
       patch(container, render, { key: 'key' });
-      var el = container.firstChild;      
+      var el = container.firstChild;
       el.appendChild(child);
       patch(container, render, { key: 'key' });
 
@@ -131,9 +131,9 @@ describe('placeholders', () => {
           elementVoid('p');
         }
       }
-  
+
       patch(container, render, { key: 'key' });
-      var el = container.firstChild;      
+      var el = container.firstChild;
       patch(el, innerRender, true);
       patch(el, innerRender, false);
 


### PR DESCRIPTION
A few cleanups from previous PRs:

- Reverse the cleanup order to removed replaced-keyed children first, then unvisited children. This allows us to avoid the `getKey` conditional in the `while` loop.
- Reset the `newAttrs` object will iterating over it to avoid a second loop.
- Misc type hint cleanups.