### PR TITLE
Several build changes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,6 @@
 {
   "loose": ["all"],
   "whitelist": [
-    "es6.properties.computed",
-    "utility.inlineEnvironmentVariables"
-  ],
-  "optional": "utility.inlineEnvironmentVariables"
+    "es6.properties.computed"
+  ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
+  - 0.12
 # This is basically redundant (ends up getting run twice) as this gets called
 # by npm on install due to the prepublish script in package.json.
 script:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "incremental-dom",
   "version": "0.1.0",
   "description": "An in-place virtual DOM library",
-  "main": "dist/incremental-dom.js",
+  "main": "dist/incremental-dom-cjs.js",
   "author": "The Incremental DOM Authors",
   "license": "Apache-2.0",
   "repository": {
@@ -24,12 +24,13 @@
   "devDependencies": {
     "browserify": "^10.2.4",
     "chai": "^3.0.0",
-    "del": "^1.2.0",
+    "del": "^2.0.2",
     "es6ify": "~1.6.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^5.1.0",
     "gulp-file": "^0.2.0",
     "gulp-gjslint": "~0.1.4",
+    "gulp-replace": "^0.5.4",
     "gulp-sourcemaps": "~1.5.1",
     "gulp-uglify": "~1.2.0",
     "gulp-util": "~3.0.4",


### PR DESCRIPTION
- Changing functions to not use `done` and instead return Promises where possible.
- Changing non-minified build to replace process.env.NODE_ENV with development.
- Changing closure build to use goog.DEBUG rather than stripping asserts.
- Changing dist target to clean the dist directory.
- Adding CommonJS build target, which is the entry point when installed from NPM. This saves the payload of the UMD header and allows for substituing process.env.NODE_ENV as desired.
- Updating node version for Travis to 0.12.