### PR TITLE
Simplify Namespace Code

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -37,13 +37,6 @@ function Context(node, prevContext) {
   this.doc = node.ownerDocument;
 
   /**
-   * Keeps track of what namespace to create new Elements in.
-   * @private
-   * @const {!Array<(string|undefined)>}
-   */
-  this.nsStack_ = [undefined];
-
-  /**
    * @const {?Context}
    */
   this.prevContext = prevContext;
@@ -58,30 +51,6 @@ function Context(node, prevContext) {
    */
   this.deleted = notifications.nodesDeleted && [];
 }
-
-
-/**
- * @return {(string|undefined)} The current namespace to create Elements in.
- */
-Context.prototype.getCurrentNamespace = function() {
-  return this.nsStack_[this.nsStack_.length - 1];
-};
-
-
-/**
- * @param {string=} namespace The namespace to enter.
- */
-Context.prototype.enterNamespace = function(namespace) {
-  this.nsStack_.push(namespace);
-};
-
-
-/**
- * Exits the current namespace
- */
-Context.prototype.exitNamespace = function() {
-  this.nsStack_.pop();
-};
 
 
 /**

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -15,52 +15,32 @@
  */
 
 import { getContext } from './context';
+import { getData } from './node_data';
 
 var SVG_NS = 'http://www.w3.org/2000/svg';
 
 /**
- * Enters a tag, checking to see if it is a namespace boundary, and if so,
- * updates the current namespace.
- * @param {string} tag The tag to enter.
- */
-var enterTag = function(tag) {
-  if (tag === 'svg') {
-    getContext().enterNamespace(SVG_NS);
-  } else if (tag === 'foreignObject') {
-    getContext().enterNamespace(undefined);
-  }
-};
-
-
-/**
- * Exits a tag, checking to see if it is a namespace boundary, and if so,
- * updates the current namespace.
- * @param {string} tag The tag to enter.
- */
-var exitTag = function(tag) {
-  if (tag === 'svg' || tag === 'foreignObject') {
-    getContext().exitNamespace();
-  }
-};
-
-
-/**
  * Gets the namespace to create an element (of a given tag) in.
  * @param {string} tag The tag to get the namespace for.
- * @return {(string|undefined)} The namespace to create the tag in.
+ * @return {?string} The namespace to create the tag in.
  */
 var getNamespaceForTag = function(tag) {
   if (tag === 'svg') {
     return SVG_NS;
   }
 
-  return getContext().getCurrentNamespace();
+  var walker = getContext().walker;
+  var parent = walker.getCurrentParent();
+
+  if (getData(parent).nodeName === 'foreignObject') {
+    return null;
+  }
+
+  return parent.namespaceURI;
 };
 
 
 /** */
 export {
-  enterTag,
-  exitTag,
   getNamespaceForTag
 };

--- a/src/traversal.js
+++ b/src/traversal.js
@@ -16,30 +16,6 @@
 
 import { getContext } from './context';
 import { getData } from './node_data';
-import {
-  enterTag,
-  exitTag
-} from './namespace';
-
-
-/**
- * Enters an Element, setting the current namespace for nested elements.
- * @param {Node} node
- */
-var enterNode = function(node) {
-  var data = getData(node);
-  enterTag(data.nodeName);
-};
-
-
-/**
- * Exits an Element, unwinding the current namespace to the previous value.
- * @param {Node} node
- */
-var exitNode = function(node) {
-  var data = getData(node);
-  exitTag(data.nodeName);
-};
 
 
 /**
@@ -61,7 +37,6 @@ var markVisited = function(node) {
 var firstChild = function() {
   var context = getContext();
   var walker = context.walker;
-  enterNode(walker.currentNode);
   walker.firstChild();
 };
 
@@ -84,7 +59,6 @@ var parentNode = function() {
   var context = getContext();
   var walker = context.walker;
   walker.parentNode();
-  exitNode(walker.currentNode);
 };
 
 

--- a/test/functional/element_creation.js
+++ b/test/functional/element_creation.js
@@ -131,13 +131,17 @@ describe('element creation', () => {
     it('should use createElement if no namespace has been specified', () => {
       var doc = container.ownerDocument;
       var div = doc.createElement('div');
+      var el;
       sandbox.stub(doc, 'createElement').returns(div);
 
       patch(container, () => {
-        elementVoid('div');
+        elementOpen('svg');
+          elementOpen('foreignObject');
+            el = elementVoid('div');
+          elementClose('foreignObject');
+        elementClose('svg');
       });
 
-      var el = container.childNodes[0];
       expect(el.namespaceURI).to.equal('http://www.w3.org/1999/xhtml');
       expect(doc.createElement).to.have.been.calledOnce;
     });


### PR DESCRIPTION
Removes the separate stack for namespace tracking and the duplication between `enterTag`, `exitTag`, and `getNamespaceForTag`.