### PR TITLE
Only track currentNode's parentNode

### DIFF
--- a/src/alignment.js
+++ b/src/alignment.js
@@ -73,7 +73,7 @@ var alignWithDOM = function(nodeName, key, statics) {
   var context = getContext();
   var walker = context.walker;
   var currentNode = walker.currentNode;
-  var parent = walker.getCurrentParent();
+  var parent = walker.currentParent;
   var matchingNode;
 
   // Check to see if we have a node to reuse

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -30,7 +30,7 @@ var getNamespaceForTag = function(tag) {
   }
 
   var walker = getContext().walker;
-  var parent = walker.getCurrentParent();
+  var parent = walker.currentParent;
 
   if (getData(parent).nodeName === 'foreignObject') {
     return null;

--- a/src/patch.js
+++ b/src/patch.js
@@ -30,8 +30,8 @@ import { notifications } from './notifications';
 
 if (process.env.NODE_ENV !== 'production') {
   var assertNoUnclosedTags = function(root) {
-    var openElement = getContext().walker.getCurrentParent();
-    if (!openElement) {
+    var openElement = getContext().walker.currentNode;
+    if (openElement === root) {
       return;
     }
 

--- a/src/traversal.js
+++ b/src/traversal.js
@@ -25,7 +25,7 @@ import { getData } from './node_data';
 var markVisited = function(node) {
   var context = getContext();
   var walker = context.walker;
-  var parent = walker.getCurrentParent();
+  var parent = walker.currentParent;
   var data = getData(parent);
   data.lastVisitedChild = node;
 };

--- a/src/tree_walker.js
+++ b/src/tree_walker.js
@@ -24,14 +24,6 @@
  */
 function TreeWalker(node) {
   /**
-   * Keeps track of the current parent node. This is necessary as the traversal
-   * methods may traverse past the last child and we still need a way to get
-   * back to the parent.
-   * @const @private {!Array<!Node>}
-   */
-  this.stack_ = [];
-
-  /**
    * @const {!Element|!DocumentFragment}
    */
   this.root = node;
@@ -40,22 +32,19 @@ function TreeWalker(node) {
    * @type {?Node}
    */
   this.currentNode = node;
+
+  /**
+   * @type {!Node}
+   */
+  this.currentParent = node;
 }
-
-
-/**
- * @return {!Node} The current parent of the current location in the subtree.
- */
-TreeWalker.prototype.getCurrentParent = function() {
-  return this.stack_[this.stack_.length - 1];
-};
 
 
 /**
  * Changes the current location the firstChild of the current location.
  */
 TreeWalker.prototype.firstChild = function() {
-  this.stack_.push(this.currentNode);
+  this.currentParent = this.currentNode;
   this.currentNode = this.currentNode.firstChild;
 };
 
@@ -72,7 +61,8 @@ TreeWalker.prototype.nextSibling = function() {
  * Changes the current location the parentNode of the current location.
  */
 TreeWalker.prototype.parentNode = function() {
-  this.currentNode = this.stack_.pop();
+  this.currentNode = this.currentParent;
+  this.currentParent = this.currentParent.parentNode;
 };
 
 

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -93,7 +93,7 @@ if (process.env.NODE_ENV !== 'production') {
   var assertCloseMatchesOpenTag = function(tag) {
     var context = getContext();
     var walker = context.walker;
-    var closingNode = walker.getCurrentParent();
+    var closingNode = walker.currentParent;
     var data = getData(closingNode);
 
     if (tag !== data.nodeName) {


### PR DESCRIPTION
Stealing this from your `pref` branch's pseudo-iDOM implementations.