### PR TITLE
Convert exports to function style

### DIFF
--- a/src/alignment.js
+++ b/src/alignment.js
@@ -31,13 +31,13 @@ if (process.env.NODE_ENV !== 'production') {
   * @param {string=} tag The tag name of the Element.
   * @param {?string=} key The key of the Element.
   */
-  var assertKeyedTagMatches = function(node, tag, key) {
+  function assertKeyedTagMatches(node, tag, key) {
     var nodeName = getData(node).nodeName;
     if (nodeName !== tag) {
       throw new Error('Was expecting node with key "' + key + '" to be a ' +
           tag + ', not a ' + nodeName + '.');
     }
-  };
+  }
 }
 
 
@@ -49,14 +49,14 @@ if (process.env.NODE_ENV !== 'production') {
  * @param {?string=} key An optional key that identifies a node.
  * @return {boolean} True if the node matches, false otherwise.
  */
-var matches = function(node, nodeName, key) {
+function matches(node, nodeName, key) {
   var data = getData(node);
 
   // Key check is done using double equals as we want to treat a null key the
   // same as undefined. This should be okay as the only values allowed are
   // strings, null and undefined so the == semantics are not too weird.
   return key == data.key && nodeName === data.nodeName;
-};
+}
 
 
 /**
@@ -69,7 +69,7 @@ var matches = function(node, nodeName, key) {
  *     name-value pairs.
  * @return {!Node} The matching node.
  */
-var alignWithDOM = function(nodeName, key, statics) {
+export function alignWithDOM(nodeName, key, statics) {
   var context = getContext();
   var walker = context.walker;
   var currentNode = walker.currentNode;
@@ -115,7 +115,7 @@ var alignWithDOM = function(nodeName, key, statics) {
   }
 
   return matchingNode;
-};
+}
 
 
 /**
@@ -123,7 +123,7 @@ var alignWithDOM = function(nodeName, key, statics) {
  * functions were never called for them.
  * @param {Node} node
  */
-var clearUnvisitedDOM = function(node) {
+export function clearUnvisitedDOM(node) {
   var context = getContext();
   var walker = context.walker;
   var data = getData(node);
@@ -164,11 +164,4 @@ var clearUnvisitedDOM = function(node) {
   }
 
   data.keyMapValid = true;
-};
-
-
-/** */
-export {
-  alignWithDOM,
-  clearUnvisitedDOM
-};
+}

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -30,13 +30,13 @@ import {
  * @param {string} name The attribute's name.
  * @param {?(boolean|number|string)=} value The attribute's value.
  */
-var applyAttr = function(el, name, value) {
+export function applyAttr(el, name, value) {
   if (value == null) {
     el.removeAttribute(name);
   } else {
     el.setAttribute(name, value);
   }
-};
+}
 
 /**
  * Applies a property to a given Element.
@@ -44,9 +44,9 @@ var applyAttr = function(el, name, value) {
  * @param {string} name The property's name.
  * @param {*} value The property's value.
  */
-var applyProp = function(el, name, value) {
+export function applyProp(el, name, value) {
   el[name] = value;
-};
+}
 
 
 /**
@@ -57,7 +57,7 @@ var applyProp = function(el, name, value) {
  * @param {string|Object<string,string>} style The style to set. Either a
  *     string of css or an object containing property-value pairs.
  */
-var applyStyle = function(el, name, style) {
+function applyStyle(el, name, style) {
   if (typeof style === 'string') {
     el.style.cssText = style;
   } else {
@@ -70,7 +70,7 @@ var applyStyle = function(el, name, style) {
       }
     }
   }
-};
+}
 
 
 /**
@@ -81,7 +81,7 @@ var applyStyle = function(el, name, style) {
  *     function it is set on the Element, otherwise, it is set as an HTML
  *     attribute.
  */
-var applyAttributeTyped = function(el, name, value) {
+function applyAttributeTyped(el, name, value) {
   var type = typeof value;
 
   if (type === 'object' || type === 'function') {
@@ -89,7 +89,7 @@ var applyAttributeTyped = function(el, name, value) {
   } else {
     applyAttr(el, name, /** @type {?(boolean|number|string)} */(value));
   }
-};
+}
 
 
 /**
@@ -98,7 +98,7 @@ var applyAttributeTyped = function(el, name, value) {
  * @param {string} name The attribute's name.
  * @param {*} value The attribute's value.
  */
-var updateAttribute = function(el, name, value) {
+export function updateAttribute(el, name, value) {
   var data = getData(el);
   var attrs = data.attrs;
 
@@ -110,14 +110,14 @@ var updateAttribute = function(el, name, value) {
   mutator(el, name, value);
 
   attrs[name] = value;
-};
+}
 
 
 /**
  * A publicly mutable object to provide custom mutators for attributes.
  * @const {!Object<string, function(!Element, string, *)>}
  */
-var attributes = createMap();
+export var attributes = createMap();
 
 // Special generic mutator that's called for any attribute that does not
 // have a specific mutator.
@@ -126,12 +126,3 @@ attributes[symbols.default] = applyAttributeTyped;
 attributes[symbols.placeholder] = function() {};
 
 attributes['style'] = applyStyle;
-
-
-/** */
-export {
-  updateAttribute,
-  applyProp,
-  applyAttr,
-  attributes
-};

--- a/src/context.js
+++ b/src/context.js
@@ -98,31 +98,23 @@ var context;
  * Enters a new patch context.
  * @param {!Element|!DocumentFragment} node
  */
-var enterContext = function(node) {
+export function enterContext(node) {
   context = new Context(node, context);
-};
+}
 
 
 /**
  * Restores the previous patch context.
  */
-var restoreContext = function() {
+export function restoreContext() {
   context = context.prevContext;
-};
+}
 
 
 /**
  * Gets the current patch context.
  * @return {?Context}
  */
-var getContext = function() {
+export function getContext() {
   return context;
-};
-
-
-/** */
-export {
-  enterContext,
-  restoreContext,
-  getContext
-};
+}

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -24,7 +24,7 @@ var SVG_NS = 'http://www.w3.org/2000/svg';
  * @param {string} tag The tag to get the namespace for.
  * @return {?string} The namespace to create the tag in.
  */
-var getNamespaceForTag = function(tag) {
+export function getNamespaceForTag(tag) {
   if (tag === 'svg') {
     return SVG_NS;
   }
@@ -37,10 +37,4 @@ var getNamespaceForTag = function(tag) {
   }
 
   return parent.namespaceURI;
-};
-
-
-/** */
-export {
-  getNamespaceForTag
-};
+}

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -90,11 +90,11 @@ function NodeData(nodeName, key) {
  * @param {?string=} key The key that identifies the node.
  * @return {!NodeData} The newly initialized data object
  */
-var initData = function(node, nodeName, key) {
+export function initData(node, nodeName, key) {
   var data = new NodeData(nodeName, key);
   node['__incrementalDOMData'] = data;
   return data;
-};
+}
 
 
 /**
@@ -103,7 +103,7 @@ var initData = function(node, nodeName, key) {
  * @param {Node} node The node to retrieve the data for.
  * @return {!NodeData} The NodeData for this Node.
  */
-var getData = function(node) {
+export function getData(node) {
   var data = node['__incrementalDOMData'];
 
   if (!data) {
@@ -118,11 +118,4 @@ var getData = function(node) {
   }
 
   return data;
-};
-
-
-/** */
-export {
-  getData,
-  initData
-};
+}

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -32,7 +32,7 @@ import { createMap } from './util';
  *     the static attributes for the Element.
  * @return {!Element}
  */
-var createElement = function(doc, tag, key, statics) {
+function createElement(doc, tag, key, statics) {
   var namespace = getNamespaceForTag(tag);
   var el;
 
@@ -51,7 +51,7 @@ var createElement = function(doc, tag, key, statics) {
   }
 
   return el;
-};
+}
 
 
 /**
@@ -66,13 +66,13 @@ var createElement = function(doc, tag, key, statics) {
  *     the static attributes for the Element.
  * @return {!Node}
  */
-var createNode = function(doc, nodeName, key, statics) {
+export function createNode(doc, nodeName, key, statics) {
   if (nodeName === '#text') {
     return doc.createTextNode('');
   }
 
   return createElement(doc, nodeName, key, statics);
-};
+}
 
 
 /**
@@ -81,7 +81,7 @@ var createNode = function(doc, nodeName, key, statics) {
  * @return {!Object<string, !Element>} A mapping of keys to the children of the
  *     Element.
  */
-var createKeyMap = function(el) {
+function createKeyMap(el) {
   var map = createMap();
   var children = el.children;
   var count = children.length;
@@ -96,7 +96,7 @@ var createKeyMap = function(el) {
   }
 
   return map;
-};
+}
 
 
 /**
@@ -105,7 +105,7 @@ var createKeyMap = function(el) {
  * @param {!Node} el
  * @return {!Object<string, !Node>} A mapping of keys to child Elements
  */
-var getKeyMap = function(el) {
+function getKeyMap(el) {
   var data = getData(el);
 
   if (!data.keyMap) {
@@ -113,7 +113,7 @@ var getKeyMap = function(el) {
   }
 
   return data.keyMap;
-};
+}
 
 
 /**
@@ -122,9 +122,9 @@ var getKeyMap = function(el) {
  * @param {?string=} key
  * @return {?Element} The child corresponding to the key.
  */
-var getChild = function(parent, key) {
+export function getChild(parent, key) {
   return /** @type {?Element} */(key && getKeyMap(parent)[key]);
-};
+}
 
 
 /**
@@ -135,14 +135,6 @@ var getChild = function(parent, key) {
  * @param {string} key A key to identify the child with.
  * @param {!Node} child The child to register.
  */
-var registerChild = function(parent, key, child) {
+export function registerChild(parent, key, child) {
   getKeyMap(parent)[key] = child;
-};
-
-
-/** */
-export {
-  createNode,
-  getChild,
-  registerChild
-};
+}

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -15,7 +15,7 @@
  */
 
 /** */
-var notifications = {
+export var notifications = {
   /**
    * Called after patch has compleated with any Nodes that have been created
    * and added to the DOM.
@@ -30,8 +30,4 @@ var notifications = {
    * @type {?function(Array<!Node>)}
    */
   nodesDeleted: null
-};
-
-export {
-  notifications
 };

--- a/src/patch.js
+++ b/src/patch.js
@@ -29,7 +29,7 @@ import { notifications } from './notifications';
 
 
 if (process.env.NODE_ENV !== 'production') {
-  var assertNoUnclosedTags = function(root) {
+  function assertNoUnclosedTags(root) {
     var openElement = getContext().walker.getCurrentParent();
     if (!openElement) {
       return;
@@ -43,7 +43,7 @@ if (process.env.NODE_ENV !== 'production') {
 
     throw new Error('One or more tags were not closed:\n' +
         openTags.join('\n'));
-  };
+  }
 }
 
 
@@ -57,7 +57,7 @@ if (process.env.NODE_ENV !== 'production') {
  * @param {T=} data An argument passed to fn to represent DOM state.
  * @template T
  */
-var patch = function(node, fn, data) {
+export function patch(node, fn, data) {
   enterContext(node);
 
   firstChild();
@@ -71,10 +71,4 @@ var patch = function(node, fn, data) {
 
   getContext().notifyChanges();
   restoreContext();
-};
-
-
-/** */
-export {
-  patch
-};
+}

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-var symbols = {
+export var symbols = {
   default: '__default',
 
   placeholder: '__placeholder'
-};
-
-/** */
-export {
-  symbols
 };

--- a/src/traversal.js
+++ b/src/traversal.js
@@ -22,49 +22,41 @@ import { getData } from './node_data';
  * Marks node's parent as having visited node.
  * @param {Node} node
  */
-var markVisited = function(node) {
+function markVisited(node) {
   var context = getContext();
   var walker = context.walker;
   var parent = walker.getCurrentParent();
   var data = getData(parent);
   data.lastVisitedChild = node;
-};
+}
 
 
 /**
  * Changes to the first child of the current node.
  */
-var firstChild = function() {
+export function firstChild() {
   var context = getContext();
   var walker = context.walker;
   walker.firstChild();
-};
+}
 
 
 /**
  * Changes to the next sibling of the current node.
  */
-var nextSibling = function() {
+export function nextSibling() {
   var context = getContext();
   var walker = context.walker;
   markVisited(walker.currentNode);
   walker.nextSibling();
-};
+}
 
 
 /**
  * Changes to the parent of the current node, removing any unvisited children.
  */
-var parentNode = function() {
+export function parentNode() {
   var context = getContext();
   var walker = context.walker;
   walker.parentNode();
-};
-
-
-/** */
-export {
-  firstChild,
-  nextSibling,
-  parentNode
-};
+}

--- a/src/tree_walker.js
+++ b/src/tree_walker.js
@@ -22,7 +22,7 @@
  *     walker should start traversing.
  * @constructor
  */
-function TreeWalker(node) {
+export function TreeWalker(node) {
   /**
    * Keeps track of the current parent node. This is necessary as the traversal
    * methods may traverse past the last child and we still need a way to get
@@ -73,10 +73,4 @@ TreeWalker.prototype.nextSibling = function() {
  */
 TreeWalker.prototype.parentNode = function() {
   this.currentNode = this.stack_.pop();
-};
-
-
-/** */
-export {
-  TreeWalker
 };

--- a/src/util.js
+++ b/src/util.js
@@ -33,23 +33,15 @@ var create = Object.create;
  * @param {string} property The property to check.
  * @return {boolean} Whether map has property.
  */
-var has = function(map, property) {
+export function has(map, property) {
   return hasOwnProperty.call(map, property);
-};
+}
 
 
 /**
  * Creates an map object without a prototype.
  * @return {!Object}
  */
-var createMap = function() {
+export function createMap() {
   return create(null);
-};
-
-
-/** */
-export {
-  createMap,
-  has
-};
-
+}

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -55,22 +55,22 @@ if (process.env.NODE_ENV !== 'production') {
 
 
   /** Makes sure that the caller is not where attributes are expected. */
-  var assertNotInAttributes = function() {
+  function assertNotInAttributes() {
     if (inAttributes) {
       throw new Error('Was not expecting a call to attr or elementOpenEnd, ' +
           'they must follow a call to elementOpenStart.');
     }
-  };
+  }
 
 
   /** Makes sure that the caller is where attributes are expected. */
-  var assertInAttributes = function() {
+  function assertInAttributes() {
     if (!inAttributes) {
       throw new Error('Was expecting a call to attr or elementOpenEnd. ' +
           'elementOpenStart must be followed by zero or more calls to attr, ' +
           'then one call to elementOpenEnd.');
     }
-  };
+  }
 
 
   /**
@@ -79,18 +79,18 @@ if (process.env.NODE_ENV !== 'production') {
    * placeholder elements to be re-used as non-placeholders and vice versa.
    * @param {string} key
    */
-  var assertPlaceholderKeySpecified = function(key) {
+  function assertPlaceholderKeySpecified(key) {
     if (!key) {
       throw new Error('Placeholder elements must have a key specified.');
     }
-  };
+  }
 
 
   /**
    * Makes sure that tags are correctly nested.
    * @param {string} tag
    */
-  var assertCloseMatchesOpenTag = function(tag) {
+  function assertCloseMatchesOpenTag(tag) {
     var context = getContext();
     var walker = context.walker;
     var closingNode = walker.getCurrentParent();
@@ -100,19 +100,19 @@ if (process.env.NODE_ENV !== 'production') {
       throw new Error('Received a call to close ' + tag + ' but ' +
             data.nodeName + ' was open.');
     }
-  };
+  }
 
 
   /** Updates the state to being in an attribute declaration. */
-  var setInAttributes = function() {
+  function setInAttributes() {
     inAttributes = true;
-  };
+  }
 
 
   /** Updates the state to not being in an attribute declaration. */
-  var setNotInAttributes = function() {
+  function setNotInAttributes() {
     inAttributes = false;
-  };
+  }
 }
 
 
@@ -128,7 +128,7 @@ if (process.env.NODE_ENV !== 'production') {
  *     for the Element.
  * @return {!Element} The corresponding Element.
  */
-var elementOpen = function(tag, key, statics, var_args) {
+export function elementOpen(tag, key, statics, var_args) {
   if (process.env.NODE_ENV !== 'production') {
     assertNotInAttributes();
   }
@@ -184,7 +184,7 @@ var elementOpen = function(tag, key, statics, var_args) {
 
   firstChild();
   return node;
-};
+}
 
 
 /**
@@ -201,7 +201,7 @@ var elementOpen = function(tag, key, statics, var_args) {
  *     static attributes for the Element. These will only be set once when the
  *     Element is created.
  */
-var elementOpenStart = function(tag, key, statics) {
+export function elementOpenStart(tag, key, statics) {
   if (process.env.NODE_ENV !== 'production') {
     assertNotInAttributes();
     setInAttributes();
@@ -210,7 +210,7 @@ var elementOpenStart = function(tag, key, statics) {
   argsBuilder[0] = tag;
   argsBuilder[1] = key;
   argsBuilder[2] = statics;
-};
+}
 
 
 /***
@@ -220,20 +220,20 @@ var elementOpenStart = function(tag, key, statics) {
  * @param {string} name
  * @param {*} value
  */
-var attr = function(name, value) {
+export function attr(name, value) {
   if (process.env.NODE_ENV !== 'production') {
     assertInAttributes();
   }
 
   argsBuilder.push(name, value);
-};
+}
 
 
 /**
  * Closes an open tag started with elementOpenStart.
  * @return {!Element} The corresponding Element.
  */
-var elementOpenEnd = function() {
+export function elementOpenEnd() {
   if (process.env.NODE_ENV !== 'production') {
     assertInAttributes();
     setNotInAttributes();
@@ -242,7 +242,7 @@ var elementOpenEnd = function() {
   var node = elementOpen.apply(null, argsBuilder);
   argsBuilder.length = 0;
   return node;
-};
+}
 
 
 /**
@@ -251,7 +251,7 @@ var elementOpenEnd = function() {
  * @param {string} tag The element's tag.
  * @return {!Element} The corresponding Element.
  */
-var elementClose = function(tag) {
+export function elementClose(tag) {
   if (process.env.NODE_ENV !== 'production') {
     assertNotInAttributes();
     assertCloseMatchesOpenTag(tag);
@@ -265,7 +265,7 @@ var elementClose = function(tag) {
 
   nextSibling();
   return node;
-};
+}
 
 
 /**
@@ -282,11 +282,11 @@ var elementClose = function(tag) {
  *     for the Element.
  * @return {!Element} The corresponding Element.
  */
-var elementVoid = function(tag, key, statics, var_args) {
+export function elementVoid(tag, key, statics, var_args) {
   var node = elementOpen.apply(null, arguments);
   elementClose.apply(null, arguments);
   return node;
-};
+}
 
 
 /**
@@ -306,7 +306,7 @@ var elementVoid = function(tag, key, statics, var_args) {
  *     for the Element.
  * @return {!Element} The corresponding Element.
  */
-var elementPlaceholder = function(tag, key, statics, var_args) {
+export function elementPlaceholder(tag, key, statics, var_args) {
   if (process.env.NODE_ENV !== 'production') {
     assertPlaceholderKeySpecified(key);
   }
@@ -315,7 +315,7 @@ var elementPlaceholder = function(tag, key, statics, var_args) {
   updateAttribute(node, symbols.placeholder, true);
   elementClose.apply(null, arguments);
   return node;
-};
+}
 
 
 /**
@@ -327,7 +327,7 @@ var elementPlaceholder = function(tag, key, statics, var_args) {
  *     changed.
  * @return {!Text} The corresponding text node.
  */
-var text = function(value, var_args) {
+export function text(value, var_args) {
   if (process.env.NODE_ENV !== 'production') {
     assertNotInAttributes();
   }
@@ -348,17 +348,4 @@ var text = function(value, var_args) {
 
   nextSibling();
   return node;
-};
-
-
-/** */
-export {
-  elementOpenStart,
-  elementOpenEnd,
-  elementOpen,
-  elementVoid,
-  elementClose,
-  elementPlaceholder,
-  text,
-  attr
-};
+}


### PR DESCRIPTION
Prevents an issue with overwriting publicly exposed methods. Most notably, `iDOM.applyAttr` could be overridden:

```js
var applyAttributeTyped = function(el, name, value) {
  var type = typeof value;

  if (type === 'object' || type === 'function') {
    exports.applyProp(el, name, value);
  } else {
    exports.applyAttr(el, name, value);
  }
}
```

Now, they use the private references internally:

```js
function applyAttributeTyped(el, name, value) {
  var type = typeof value;

  if (type === 'object' || type === 'function') {
    applyProp(el, name, value);
  } else {
    applyAttr(el, name, value);
  }
}
```