### PR TITLE
Statics Diffing

### DIFF
--- a/src/alignment.js
+++ b/src/alignment.js
@@ -52,10 +52,7 @@ if (process.env.NODE_ENV !== 'production') {
 var matches = function(node, nodeName, key) {
   var data = getData(node);
 
-  // Key check is done using double equals as we want to treat a null key the
-  // same as undefined. This should be okay as the only values allowed are
-  // strings, null and undefined so the == semantics are not too weird.
-  return key == data.key && nodeName === data.nodeName;
+  return key === data.key && nodeName === data.nodeName;
 };
 
 

--- a/src/alignment.js
+++ b/src/alignment.js
@@ -46,7 +46,7 @@ if (process.env.NODE_ENV !== 'production') {
  *
  * @param {!Node} node An HTML node, typically an HTMLElement or Text.
  * @param {?string} nodeName The nodeName for this node.
- * @param {?string=} key An optional key that identifies a node.
+ * @param {?string} key An optional key that identifies a node.
  * @return {boolean} True if the node matches, false otherwise.
  */
 var matches = function(node, nodeName, key) {
@@ -61,8 +61,8 @@ var matches = function(node, nodeName, key) {
  * corresponding DOM node to the correct location or creating it if necessary.
  * @param {string} nodeName For an Element, this should be a valid tag string.
  *     For a Text, this should be #text.
- * @param {?string=} key The key used to identify this element.
- * @param {?Array<*>=} statics For an Element, this should be an array of
+ * @param {?string} key The key used to identify this element.
+ * @param {?Array<*>} statics For an Element, this should be an array of
  *     name-value pairs.
  * @return {!Node} The matching node.
  */

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -114,6 +114,47 @@ var updateAttribute = function(el, name, value) {
 
 
 /**
+ * Updates the static attributes of the Element.
+ * @param {!Element} el
+ * @param {?Array<*>=} statics An array of attribute name/value pairs of the
+ *     static attributes for the Element. These will only be set once when the
+ *     Element is created.
+ */
+var updateStatics = function(el, statics) {
+  var data = getData(el);
+  var newAttrs = data.statics;
+  var i;
+
+  if (!newAttrs) {
+    var oldStatics = data.staticsArr;
+    newAttrs = data.statics = createMap();
+    if (oldStatics) {
+      for (i = 0; i < oldStatics.length; i += 2) {
+        newAttrs[oldStatics[i]] = undefined;
+      }
+    }
+  }
+
+  if (statics) {
+    for (i = 0; i < statics.length; i += 2) {
+      newAttrs[statics[i]] = statics[i + 1];
+    }
+  }
+
+  updateAttributes(el, newAttrs);
+  data.staticsArr = statics;
+};
+
+
+var updateAttributes = function(el, attributes) {
+  for (var attr in attributes) {
+    updateAttribute(el, attr, attributes[attr]);
+    attributes[attr] = undefined;
+  }
+};
+
+
+/**
  * A publicly mutable object to provide custom mutators for attributes.
  * @const {!Object<string, function(!Element, string, *)>}
  */
@@ -131,7 +172,9 @@ attributes['style'] = applyStyle;
 /** */
 export {
   updateAttribute,
+  updateAttributes,
   applyProp,
   applyAttr,
-  attributes
+  attributes,
+  updateStatics
 };

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -122,16 +122,13 @@ var updateAttribute = function(el, name, value) {
  */
 var updateStatics = function(el, statics) {
   var data = getData(el);
-  var newAttrs = data.statics;
+  var oldStatics = data.statics;
+  var newAttrs = createMap();
   var i;
 
-  if (!newAttrs) {
-    var oldStatics = data.staticsArr;
-    newAttrs = data.statics = createMap();
-    if (oldStatics) {
-      for (i = 0; i < oldStatics.length; i += 2) {
-        newAttrs[oldStatics[i]] = undefined;
-      }
+  if (oldStatics) {
+    for (i = 0; i < oldStatics.length; i += 2) {
+      newAttrs[oldStatics[i]] = undefined;
     }
   }
 
@@ -142,7 +139,7 @@ var updateStatics = function(el, statics) {
   }
 
   updateAttributes(el, newAttrs);
-  data.staticsArr = statics;
+  data.statics = statics;
 };
 
 

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -116,7 +116,7 @@ var updateAttribute = function(el, name, value) {
 /**
  * Updates the static attributes of the Element.
  * @param {!Element} el
- * @param {?Array<*>=} statics An array of attribute name/value pairs of the
+ * @param {?Array<*>} statics An array of attribute name/value pairs of the
  *     static attributes for the Element. These will only be set once when the
  *     Element is created.
  */
@@ -143,6 +143,14 @@ var updateStatics = function(el, statics) {
 };
 
 
+/**
+ * Updates each attribute in attributes to the correct value. Clears all values
+ * afterwards, so that only new attributes can be set on the next run.
+ * @param {!Element} el
+ * @param {!Object<string, *>} attributes An array of attribute name/value pairs
+ *     of the static attributes for the Element. These will only be set once
+ *     when the Element is created.
+ */
 var updateAttributes = function(el, attributes) {
   for (var attr in attributes) {
     updateAttribute(el, attr, attributes[attr]);

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -23,7 +23,7 @@ import { createMap } from './util';
  * @param {?string=} key
  * @constructor
  */
-function NodeData(nodeName, key, staticsArr) {
+function NodeData(nodeName, key, statics) {
   /**
    * The attributes and their values.
    * @const {!Object<string, *>}
@@ -81,16 +81,10 @@ function NodeData(nodeName, key, staticsArr) {
   this.text = null;
 
   /**
-   * The static attributes for this Node.
-   * @type {?Object<string, *>}
-   */
-  this.statics = null;
-
-  /**
    * A reference to the static attributes of the Node.
    * @type {?Array<*>}
    */
-  this.staticsArr = staticsArr;
+  this.statics = statics;
 }
 
 

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -20,7 +20,8 @@ import { createMap } from './util';
 /**
  * Keeps track of information needed to perform diffs for a given DOM node.
  * @param {!string} nodeName
- * @param {?string=} key
+ * @param {?string} key
+ * @param {?Array<*>} statics
  * @constructor
  */
 function NodeData(nodeName, key, statics) {
@@ -93,7 +94,9 @@ function NodeData(nodeName, key, statics) {
  *
  * @param {Node} node The node to initialize data for.
  * @param {string} nodeName The node name of node.
- * @param {?string=} key The key that identifies the node.
+ * @param {?string} key The key that identifies the node.
+ * @param {?Array<*>} statics An array of attribute name/value pairs of
+ *     the static attributes for the Element.
  * @return {!NodeData} The newly initialized data object
  */
 var initData = function(node, nodeName, key, statics) {
@@ -120,7 +123,7 @@ var getData = function(node) {
       key = node.getAttribute('key');
     }
 
-    data = initData(node, nodeName, key);
+    data = initData(node, nodeName, key, null);
   }
 
   return data;

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -23,10 +23,10 @@ import { createMap } from './util';
  * @param {?string=} key
  * @constructor
  */
-function NodeData(nodeName, key) {
+function NodeData(nodeName, key, staticsArr) {
   /**
    * The attributes and their values.
-   * @const
+   * @const {!Object<string, *>}
    */
   this.attrs = createMap();
 
@@ -47,7 +47,7 @@ function NodeData(nodeName, key) {
   /**
    * The key used to identify this node, used to preserve DOM nodes when they
    * move within their parent.
-   * @const
+   * @const {?string}
    */
   this.key = key;
 
@@ -79,6 +79,18 @@ function NodeData(nodeName, key) {
    * @type {?string}
    */
   this.text = null;
+
+  /**
+   * The static attributes for this Node.
+   * @type {?Object<string, *>}
+   */
+  this.statics = null;
+
+  /**
+   * A reference to the static attributes of the Node.
+   * @type {?Array<*>}
+   */
+  this.staticsArr = staticsArr;
 }
 
 
@@ -90,8 +102,8 @@ function NodeData(nodeName, key) {
  * @param {?string=} key The key that identifies the node.
  * @return {!NodeData} The newly initialized data object
  */
-var initData = function(node, nodeName, key) {
-  var data = new NodeData(nodeName, key);
+var initData = function(node, nodeName, key, statics) {
+  var data = new NodeData(nodeName, key, statics);
   node['__incrementalDOMData'] = data;
   return data;
 };

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -50,8 +50,8 @@ var createElement = function(doc, tag, key) {
  * @param {Document} doc The document with which to create the Node.
  * @param {string} nodeName The tag if creating an element or #text to create
  *     a Text.
- * @param {?string=} key A key to identify the Element.
- * @param {?Array<*>=} statics The static data to initialize the Node
+ * @param {?string} key A key to identify the Element.
+ * @param {?Array<*>} statics The static data to initialize the Node
  *     with. For an Element, an array of attribute name/value pairs of
  *     the static attributes for the Element.
  * @return {!Node}
@@ -61,7 +61,7 @@ var createNode = function(doc, nodeName, key, statics) {
   if (nodeName === '#text') {
     node = doc.createTextNode('');
   } else {
-    node = createElement(doc, nodeName, key, statics);
+    node = createElement(doc, nodeName, key);
   }
 
   initData(node, nodeName, key, statics);

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -64,7 +64,7 @@ var createNode = function(doc, nodeName, key, statics) {
     node = createElement(doc, nodeName, key, statics);
   }
 
-  initData(node, nodeName, key);
+  initData(node, nodeName, key, statics);
 
   if (statics) {
     for (var i = 0; i < statics.length; i += 2) {

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -18,7 +18,11 @@ import {
   alignWithDOM,
   clearUnvisitedDOM
 } from './alignment';
-import { updateAttribute } from './attributes';
+import {
+  updateAttribute,
+  updateAttributes,
+  updateStatics
+} from './attributes';
 import { getData } from './node_data';
 import { getContext } from './context';
 import {
@@ -98,7 +102,7 @@ if (process.env.NODE_ENV !== 'production') {
 
     if (tag !== data.nodeName) {
       throw new Error('Received a call to close ' + tag + ' but ' +
-            data.nodeName + ' was open.');
+          data.nodeName + ' was open.');
     }
   };
 
@@ -133,8 +137,15 @@ var elementOpen = function(tag, key, statics, var_args) {
     assertNotInAttributes();
   }
 
+  key = key || null;
+  statics = statics || null;
+
   var node = /** @type {!Element}*/(alignWithDOM(tag, key, statics));
   var data = getData(node);
+
+  if (data.staticsArr !== statics) {
+    updateStatics(node, statics);
+  }
 
   /*
    * Checks to see if one or more attributes have changed for a given Element.
@@ -172,10 +183,7 @@ var elementOpen = function(tag, key, statics, var_args) {
       newAttrs[arguments[i]] = arguments[i + 1];
     }
 
-    for (var attr in newAttrs) {
-      updateAttribute(node, attr, newAttrs[attr]);
-      newAttrs[attr] = undefined;
-    }
+    updateAttributes(node, newAttrs);
   }
 
   firstChild();

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -143,7 +143,7 @@ var elementOpen = function(tag, key, statics, var_args) {
   var node = /** @type {!Element}*/(alignWithDOM(tag, key, statics));
   var data = getData(node);
 
-  if (data.staticsArr !== statics) {
+  if (data.statics !== statics) {
     updateStatics(node, statics);
   }
 

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -336,7 +336,7 @@ var text = function(value, var_args) {
     assertNotInAttributes();
   }
 
-  var node = /** @type {!Text}*/(alignWithDOM('#text', null));
+  var node = /** @type {!Text}*/(alignWithDOM('#text', null, null));
   var data = getData(node);
 
   if (data.text !== value) {

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -37,7 +37,7 @@ describe('attribute updates', () => {
 
   describe('for conditional attributes', () => {
     function render(attrs) {
-      elementOpenStart('div', '', []);
+      elementOpenStart('div');
       for (var attrName in attrs) {
           attr(attrName, attrs[attrName]);
       }
@@ -118,7 +118,7 @@ describe('attribute updates', () => {
     it('should not be set as attributes', () => {
       var fn = () =>{};
       patch(container, () => {
-        elementVoid('div', '', null,
+        elementVoid('div', null, null,
             'fn', fn);
       });
       var el = container.childNodes[0];
@@ -129,7 +129,7 @@ describe('attribute updates', () => {
     it('should be set on the node', () => {
       var fn = () =>{};
       patch(container, () => {
-        elementVoid('div', '', null,
+        elementVoid('div', null, null,
             'fn', fn);
       });
       var el = container.childNodes[0];
@@ -142,7 +142,7 @@ describe('attribute updates', () => {
     it('should not be set as attributes', () => {
       var obj = {};
       patch(container, () => {
-        elementVoid('div', '', null,
+        elementVoid('div', null, null,
             'obj', obj);
       });
       var el = container.childNodes[0];
@@ -153,7 +153,7 @@ describe('attribute updates', () => {
     it('should be set on the node', () => {
       var obj = {};
       patch(container, () => {
-        elementVoid('div', '', null,
+        elementVoid('div', null, null,
             'obj', obj);
       });
       var el = container.childNodes[0];
@@ -164,7 +164,7 @@ describe('attribute updates', () => {
 
   describe('for style', () => {
     function render(style) {
-      elementVoid('div', '', [],
+      elementVoid('div', null, null,
           'style', style);
     }
 

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -224,5 +224,65 @@ describe('attribute updates', () => {
       expect(el.getAttribute('class')).to.equal('foo');
     });
   });
+
+  describe('for static attributes', () => {
+    var statics1 = ['id', 'id'];
+    var statics2 = ['class', 'class'];
+
+    it('should handle null to static attributes', () => {
+      function render(condition) {
+        if (condition) {
+          elementVoid('div');
+        }
+        elementVoid('div', null, statics1);
+      }
+
+      patch(container, render, true);
+      patch(container, render, false);
+
+      var el = container.childNodes[0];
+
+      expect(el.id).to.equal('id');
+    });
+
+    it('should handle static attributes to null', () => {
+      function render(condition) {
+        if (condition) {
+          elementVoid('div', null, statics1);
+        }
+        elementVoid('div');
+      }
+
+      patch(container, render, true);
+      patch(container, render, false);
+
+      var el = container.childNodes[0];
+
+      expect(el.id).to.equal('');
+    });
+
+    it('should handle static attributes to another static attributes', () => {
+      function render(condition) {
+        if (condition) {
+          elementVoid('div', null, statics1);
+        }
+        elementVoid('div', null, statics2);
+        if (!condition) {
+          elementVoid('div', null, statics1);
+        }
+      }
+
+      patch(container, render, true);
+      patch(container, render, false);
+
+      var el = container.childNodes[0];
+      var el2 = container.childNodes[1];
+
+      expect(el.id).to.equal('');
+      expect(el.className).to.equal('class');
+      expect(el2.id).to.equal('id');
+      expect(el2.className).to.equal('');
+    });
+  });
 });
 

--- a/test/functional/conditional_rendering.js
+++ b/test/functional/conditional_rendering.js
@@ -36,15 +36,15 @@ describe('conditional rendering', () => {
 
   describe('nodes', () => {
     function render(condition) {
-      elementOpen('div', '', ['id', 'outer']);
-        elementVoid('div', '', ['id', 'one']);
+      elementOpen('div', 'outer', ['id', 'outer']);
+        elementVoid('div', 'one', ['id', 'one']);
 
         if (condition) {
-          elementVoid('div', '', ['id', 'conditional-one']);
-          elementVoid('div', '', ['id', 'conditional-two']);
+          elementVoid('div', 'conditional-one', ['id', 'conditional-one']);
+          elementVoid('div', 'conditional-two', ['id', 'conditional-two']);
         }
 
-        elementVoid('span', '', ['id', 'two' ]);
+        elementVoid('span', 'two', ['id', 'two' ]);
       elementClose('div');
     }
 
@@ -79,11 +79,11 @@ describe('conditional rendering', () => {
 
   describe('with only conditional childNodes', () => {
     function render(condition) {
-      elementOpen('div', '', ['id', 'outer']);
+      elementOpen('div', 'outer', ['id', 'outer']);
 
         if (condition) {
-          elementVoid('div', '', ['id', 'conditional-one' ]);
-          elementVoid('div', '', ['id', 'conditional-two' ]);
+          elementVoid('div', 'conditional-one', ['id', 'conditional-one' ]);
+          elementVoid('div', 'conditional-two', ['id', 'conditional-two' ]);
         }
 
       elementClose('div');
@@ -100,20 +100,20 @@ describe('conditional rendering', () => {
 
   describe('nodes', () => {
     function render(condition) {
-      elementOpen('div', '', [],
+      elementOpen('div', null, null,
           'id', 'outer');
-        elementVoid('div', '', [],
+        elementVoid('div', null, null,
             'id', 'one' );
 
         if (condition) {
-          elementOpen('span', '', [],
+          elementOpen('span', null, null,
               'id', 'conditional-one',
               'data-foo', 'foo');
-            elementVoid('span', '', []);
+            elementVoid('span');
           elementClose('span');
         }
 
-        elementVoid('span', '', [],
+        elementVoid('span', null, null,
             'id', 'two');
       elementClose('div');
     }

--- a/test/functional/element_creation.js
+++ b/test/functional/element_creation.js
@@ -42,7 +42,7 @@ describe('element creation', () => {
 
     beforeEach(() => {
       patch(container, () => {
-        elementVoid('div', '', ['id', 'someId', 'class', 'someClass', 'data-custom', 'custom'],
+        elementVoid('div', 'key', ['id', 'someId', 'class', 'someClass', 'data-custom', 'custom'],
             'data-foo', 'Hello',
             'data-bar', 'World');
       });
@@ -111,7 +111,7 @@ describe('element creation', () => {
 
   it('should allow creation without static attributes', () => {
     patch(container, () => {
-      elementVoid('div', '', null,
+      elementVoid('div', null, null,
           'id', 'test');
     });
     var el = container.childNodes[0];

--- a/test/functional/hooks.js
+++ b/test/functional/hooks.js
@@ -42,7 +42,7 @@ describe('library hooks', () => {
 
   describe('for deciding how attributes are set', () => {
     function render(dynamicValue) {
-      elementVoid('div', null, ['staticName', 'staticValue'],
+      elementVoid('div', 'key', ['staticName', 'staticValue'],
           'dynamicName', dynamicValue);
     }
 

--- a/test/functional/keyed_items.js
+++ b/test/functional/keyed_items.js
@@ -25,7 +25,8 @@ describe('rendering with keys', () => {
 
   function render(items) {
     for(var i=0; i<items.length; i++) {
-      elementVoid('div', items[i].key, ['id', items[i].key]);
+      var key = items[i].key;
+      elementVoid('div', key, key ? ['id', key] : null);
     }
   }
 

--- a/test/functional/virtual_attributes.js
+++ b/test/functional/virtual_attributes.js
@@ -37,8 +37,8 @@ describe('virtual attribute updates', () => {
   });
 
   describe('for conditional attributes', () => {
-    function render(obj) {  
-      elementOpenStart('div', '', []);
+    function render(obj) {
+      elementOpenStart('div');
         if (obj.key) {
           attr('data-expanded', obj.key);
         }


### PR DESCRIPTION
Resolves #150.

- - -
> So I think the way forward is to add an assert when reusing a node that has statics to check if either a key is defined or if statics have the same reference.

Looking at this last night, I actually think this is the worst approach. Consider:

```jsx
var statics = ['id', 'id'];
function render(condition) {
  if (condition) {
    elementVoid('div');
  }
  elementVoid('div', null, statics);
}
```

On their own, both `div`s pass "statics have the same reference". But used together, they're a time bomb waiting for production.

This can be gotten around by requiring a key to use statics, but I don't think that's a [scalable solution](https://github.com/google/incremental-dom/issues/150#issuecomment-148496953) for templating libraries. And requiring a dev to provide a key just to write something as simple as `<a href="/foo" />` is a nonstarter.

Instead, I think treating statics as special dynamics is the best approach. Since we're provided an array reference, just check strict equality of the array. If it matches, we're done. If not, perform the same attribute-change algorithm we use for dynamics.