### PR TITLE
Testing cleanups

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,8 @@
 {
   "loose": ["all"],
   "whitelist": [
-    "es6.properties.computed"
+    "es6.modules",
+    "es6.properties.computed",
+    "es6.arrowFunctions"
   ]
 }

--- a/conf/karma.conf.js
+++ b/conf/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = function(config) {
     frameworks: ['browserify', 'mocha', 'sinon-chai'],
 
     basePath: '../',
-  
+
     files: [
       'test/**/*.js'
     ],
@@ -32,7 +32,7 @@ module.exports = function(config) {
     browserify: {
       watch: true,
       debug: true,
-      transform: ['es6ify']
+      transform: ['babelify']
     },
 
     reporters: ['progress'],

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "prepublish": "npm run dist"
   },
   "devDependencies": {
+    "babelify": "^6.4.0",
     "browserify": "^10.2.4",
     "chai": "^3.0.0",
     "del": "^2.0.2",
-    "es6ify": "~1.6.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^5.1.0",
     "gulp-file": "^0.2.0",

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -37,7 +37,7 @@ describe('attribute updates', () => {
 
   describe('for conditional attributes', () => {
     function render(attrs) {
-      elementOpenStart('div', '', []);
+      elementOpenStart('div');
       for (var attrName in attrs) {
           attr(attrName, attrs[attrName]);
       }
@@ -118,7 +118,7 @@ describe('attribute updates', () => {
     it('should not be set as attributes', () => {
       var fn = () =>{};
       patch(container, () => {
-        elementVoid('div', '', null,
+        elementVoid('div', null, null,
             'fn', fn);
       });
       var el = container.childNodes[0];
@@ -129,7 +129,7 @@ describe('attribute updates', () => {
     it('should be set on the node', () => {
       var fn = () =>{};
       patch(container, () => {
-        elementVoid('div', '', null,
+        elementVoid('div', null, null,
             'fn', fn);
       });
       var el = container.childNodes[0];
@@ -142,7 +142,7 @@ describe('attribute updates', () => {
     it('should not be set as attributes', () => {
       var obj = {};
       patch(container, () => {
-        elementVoid('div', '', null,
+        elementVoid('div', null, null,
             'obj', obj);
       });
       var el = container.childNodes[0];
@@ -153,7 +153,7 @@ describe('attribute updates', () => {
     it('should be set on the node', () => {
       var obj = {};
       patch(container, () => {
-        elementVoid('div', '', null,
+        elementVoid('div', null, null,
             'obj', obj);
       });
       var el = container.childNodes[0];
@@ -164,7 +164,7 @@ describe('attribute updates', () => {
 
   describe('for style', () => {
     function render(style) {
-      elementVoid('div', '', [],
+      elementVoid('div', null, null,
           'style', style);
     }
 

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -15,12 +15,12 @@
  */
 
 import {
-    patch,
-    elementOpenStart,
-    elementOpenEnd,
-    attr,
-    elementClose,
-    elementVoid
+  patch,
+  elementOpenStart,
+  elementOpenEnd,
+  attr,
+  elementClose,
+  elementVoid
 } from '../../index';
 
 describe('attribute updates', () => {
@@ -39,7 +39,7 @@ describe('attribute updates', () => {
     function render(attrs) {
       elementOpenStart('div');
       for (var attrName in attrs) {
-          attr(attrName, attrs[attrName]);
+        attr(attrName, attrs[attrName]);
       }
       elementOpenEnd();
       elementClose('div');

--- a/test/functional/conditional_rendering.js
+++ b/test/functional/conditional_rendering.js
@@ -15,10 +15,10 @@
  */
 
 import {
-    patch,
-    elementOpen,
-    elementClose,
-    elementVoid
+  patch,
+  elementOpen,
+  elementClose,
+  elementVoid
 } from '../../index';
 
 

--- a/test/functional/conditional_rendering.js
+++ b/test/functional/conditional_rendering.js
@@ -36,15 +36,15 @@ describe('conditional rendering', () => {
 
   describe('nodes', () => {
     function render(condition) {
-      elementOpen('div', '', ['id', 'outer']);
-        elementVoid('div', '', ['id', 'one']);
+      elementOpen('div', 'outer', ['id', 'outer']);
+        elementVoid('div', 'one', ['id', 'one']);
 
         if (condition) {
-          elementVoid('div', '', ['id', 'conditional-one']);
-          elementVoid('div', '', ['id', 'conditional-two']);
+          elementVoid('div', 'conditional-one', ['id', 'conditional-one']);
+          elementVoid('div', 'conditional-two', ['id', 'conditional-two']);
         }
 
-        elementVoid('span', '', ['id', 'two' ]);
+        elementVoid('span', 'two', ['id', 'two' ]);
       elementClose('div');
     }
 
@@ -79,11 +79,11 @@ describe('conditional rendering', () => {
 
   describe('with only conditional childNodes', () => {
     function render(condition) {
-      elementOpen('div', '', ['id', 'outer']);
+      elementOpen('div', 'outer', ['id', 'outer']);
 
         if (condition) {
-          elementVoid('div', '', ['id', 'conditional-one' ]);
-          elementVoid('div', '', ['id', 'conditional-two' ]);
+          elementVoid('div', 'conditional-one', ['id', 'conditional-one' ]);
+          elementVoid('div', 'conditional-two', ['id', 'conditional-two' ]);
         }
 
       elementClose('div');
@@ -100,20 +100,20 @@ describe('conditional rendering', () => {
 
   describe('nodes', () => {
     function render(condition) {
-      elementOpen('div', '', [],
+      elementOpen('div', null, null,
           'id', 'outer');
-        elementVoid('div', '', [],
+        elementVoid('div', null, null,
             'id', 'one' );
 
         if (condition) {
-          elementOpen('span', '', [],
+          elementOpen('span', null, null,
               'id', 'conditional-one',
               'data-foo', 'foo');
-            elementVoid('span', '', []);
+            elementVoid('span');
           elementClose('span');
         }
 
-        elementVoid('span', '', [],
+        elementVoid('span', null, null,
             'id', 'two');
       elementClose('div');
     }

--- a/test/functional/element_creation.js
+++ b/test/functional/element_creation.js
@@ -15,12 +15,12 @@
  */
 
 import {
-    patch,
-    elementOpen,
-    elementOpenStart,
-    elementOpenEnd,
-    elementClose,
-    elementVoid
+  patch,
+  elementOpen,
+  elementOpenStart,
+  elementOpenEnd,
+  elementClose,
+  elementVoid
 } from '../../index';
 
 describe('element creation', () => {

--- a/test/functional/element_creation.js
+++ b/test/functional/element_creation.js
@@ -42,7 +42,7 @@ describe('element creation', () => {
 
     beforeEach(() => {
       patch(container, () => {
-        elementVoid('div', '', ['id', 'someId', 'class', 'someClass', 'data-custom', 'custom'],
+        elementVoid('div', 'key', ['id', 'someId', 'class', 'someClass', 'data-custom', 'custom'],
             'data-foo', 'Hello',
             'data-bar', 'World');
       });
@@ -111,7 +111,7 @@ describe('element creation', () => {
 
   it('should allow creation without static attributes', () => {
     patch(container, () => {
-      elementVoid('div', '', null,
+      elementVoid('div', null, null,
           'id', 'test');
     });
     var el = container.childNodes[0];

--- a/test/functional/formatters.js
+++ b/test/functional/formatters.js
@@ -15,8 +15,8 @@
  */
 
 import {
-    patch,
-    text
+  patch,
+  text
 } from '../../index';
 
 
@@ -36,7 +36,7 @@ describe('formatters', () => {
     function sliceOne(str) {
       return str.slice(1);
     }
-  
+
     function prefixQuote(str) {
       return '\'' + str;
     }

--- a/test/functional/hooks.js
+++ b/test/functional/hooks.js
@@ -15,12 +15,12 @@
  */
 
 import {
-    patch,
-    text,
-    elementVoid,
-    symbols,
-    attributes,
-    notifications
+  patch,
+  text,
+  elementVoid,
+  symbols,
+  attributes,
+  notifications
 } from '../../index';
 
 
@@ -57,8 +57,7 @@ describe('library hooks', () => {
 
     afterEach(() => {
       for (var mutator in attributes) {
-        if (mutator !== symbols.default &&
-            mutator !== symbols.placeholder) {
+        if (mutator !== symbols.default && mutator !== symbols.placeholder) {
           attributes[mutator] = null;
         }
       }

--- a/test/functional/hooks.js
+++ b/test/functional/hooks.js
@@ -42,7 +42,7 @@ describe('library hooks', () => {
 
   describe('for deciding how attributes are set', () => {
     function render(dynamicValue) {
-      elementVoid('div', null, ['staticName', 'staticValue'],
+      elementVoid('div', 'key', ['staticName', 'staticValue'],
           'dynamicName', dynamicValue);
     }
 

--- a/test/functional/keyed_items.js
+++ b/test/functional/keyed_items.js
@@ -25,7 +25,8 @@ describe('rendering with keys', () => {
 
   function render(items) {
     for(var i=0; i<items.length; i++) {
-      elementVoid('div', items[i].key, ['id', items[i].key]);
+      var key = items[i].key;
+      elementVoid('div', key, key ? ['id', key] : null);
     }
   }
 

--- a/test/functional/patchInner.js
+++ b/test/functional/patchInner.js
@@ -15,14 +15,14 @@
  */
 
 import {
-    patch,
-    patchInner,
-    elementOpen,
-    elementOpenStart,
-    elementOpenEnd,
-    elementClose,
-    elementVoid,
-    text
+  patch,
+  patchInner,
+  elementOpen,
+  elementOpenStart,
+  elementOpenEnd,
+  elementClose,
+  elementVoid,
+  text
 } from '../../index';
 
 

--- a/test/functional/patchOuter.js
+++ b/test/functional/patchOuter.js
@@ -15,11 +15,11 @@
  */
 
 import {
-    patchOuter,
-    elementOpen,
-    elementClose,
-    elementVoid,
-    text
+  patchOuter,
+  elementOpen,
+  elementClose,
+  elementVoid,
+  text
 } from '../../index';
 
 
@@ -40,7 +40,7 @@ describe('patching an element', () => {
       elementVoid('div', null, null,
           'tabindex', '0');
     }
-  
+
     patchOuter(container, render);
 
     expect(container.getAttribute('tabindex')).to.equal('0');
@@ -52,7 +52,7 @@ describe('patching an element', () => {
         elementVoid('span');
       elementClose('div');
     }
-  
+
     patchOuter(container, render);
 
     expect(container.firstChild.tagName).to.equal('SPAN');
@@ -95,7 +95,7 @@ describe('patching an element', () => {
 
   it('should throw an error on an empty patch', () => {
     function render() {}
-  
+
     expect(() => patchOuter(container, render)).to.throw('There must be ' +
         'exactly one top level call corresponding to the patched element.');
   });
@@ -104,7 +104,7 @@ describe('patching an element', () => {
     function render() {
       elementVoid('span');
     }
-  
+
     expect(() => patchOuter(container, render)).to.throw('There must be ' +
         'exactly one top level call corresponding to the patched element.');
   });
@@ -114,7 +114,7 @@ describe('patching an element', () => {
       elementVoid('div');
       elementVoid('div');
     }
-  
+
     expect(() => patchOuter(container, render)).to.throw('There must be ' +
         'exactly one top level call corresponding to the patched element.');
   });

--- a/test/functional/placeholders.js
+++ b/test/functional/placeholders.js
@@ -15,11 +15,11 @@
  */
 
 import {
-    patch,
-    elementVoid,
-    elementPlaceholder,
-    text,
-    symbols
+  patch,
+  elementVoid,
+  elementPlaceholder,
+  text,
+  symbols
 } from '../../index';
 
 
@@ -51,7 +51,7 @@ describe('placeholders', () => {
       var child = document.createElement('div');
 
       patch(container, render, { key: 'key' });
-      var el = container.firstChild;      
+      var el = container.firstChild;
       el.appendChild(child);
       patch(container, render, { key: 'key' });
 
@@ -66,9 +66,9 @@ describe('placeholders', () => {
           elementVoid('p');
         }
       }
-  
+
       patch(container, render, { key: 'key' });
-      var el = container.firstChild;      
+      var el = container.firstChild;
       patch(el, innerRender, true);
       patch(el, innerRender, false);
 
@@ -89,7 +89,7 @@ describe('placeholders', () => {
 
     it('should render with specified static attributes', () => {
       patch(container, render, { key: 'key' });
-      var el = container.firstChild;      
+      var el = container.firstChild;
 
       expect(el.getAttribute('staticName')).to.equal('staticValue');
     });
@@ -99,14 +99,14 @@ describe('placeholders', () => {
         key: 'key',
         val: 'dynamicValue'
       });
-      var el = container.firstChild;      
+      var el = container.firstChild;
 
       expect(el.getAttribute('dynamicName')).to.equal('dynamicValue');
     });
 
     it('should reuse the same node', () => {
       patch(container, render, { key: 'key' });
-      var el = container.firstChild;      
+      var el = container.firstChild;
       patch(container, render, { key: 'key' });
 
       expect(container.firstChild).to.equal(el);
@@ -116,7 +116,7 @@ describe('placeholders', () => {
       var child = document.createElement('div');
 
       patch(container, render, { key: 'key' });
-      var el = container.firstChild;      
+      var el = container.firstChild;
       el.appendChild(child);
       patch(container, render, { key: 'key' });
 
@@ -131,9 +131,9 @@ describe('placeholders', () => {
           elementVoid('p');
         }
       }
-  
+
       patch(container, render, { key: 'key' });
-      var el = container.firstChild;      
+      var el = container.firstChild;
       patch(el, innerRender, true);
       patch(el, innerRender, false);
 

--- a/test/functional/text_nodes.js
+++ b/test/functional/text_nodes.js
@@ -15,8 +15,8 @@
  */
 
 import {
-    patch,
-    text
+  patch,
+  text
 } from '../../index';
 
 

--- a/test/functional/virtual_attributes.js
+++ b/test/functional/virtual_attributes.js
@@ -38,7 +38,7 @@ describe('virtual attribute updates', () => {
 
   describe('for conditional attributes', () => {
     function render(obj) {
-      elementOpenStart('div', '', []);
+      elementOpenStart('div');
         if (obj.key) {
           attr('data-expanded', obj.key);
         }

--- a/test/functional/virtual_attributes.js
+++ b/test/functional/virtual_attributes.js
@@ -15,12 +15,12 @@
  */
 
 import {
-    patch,
-    elementOpen,
-    elementOpenStart,
-    elementOpenEnd,
-    elementClose,
-    attr
+  patch,
+  elementOpen,
+  elementOpenStart,
+  elementOpenEnd,
+  elementClose,
+  attr
 } from '../../index';
 
 


### PR DESCRIPTION
A few testing cleanups:

- Use `null` for `key` and `statics` where appropriate
- Whitespace
- Use `babelify` to compile code
  - Was having issues with sourcemaps using `es6ify`
  - While we don't have a lot of ES6 code now, it'll be better for us to test using the same compiler we bundle with to catch compile errors.