### PR TITLE
Assertions

### DIFF
--- a/src/alignment.js
+++ b/src/alignment.js
@@ -22,23 +22,7 @@ import {
 import { getData } from './node_data';
 import { getContext } from './context';
 import { symbols } from './symbols';
-
-
-if (process.env.NODE_ENV !== 'production') {
-  /**
-  * Makes sure that keyed Element matches the tag name provided.
-  * @param {!Element} node The node that is being matched.
-  * @param {string=} tag The tag name of the Element.
-  * @param {?string=} key The key of the Element.
-  */
-  var assertKeyedTagMatches = function(node, tag, key) {
-    var nodeName = getData(node).nodeName;
-    if (nodeName !== tag) {
-      throw new Error('Was expecting node with key "' + key + '" to be a ' +
-          tag + ', not a ' + nodeName + '.');
-    }
-  };
-}
+import { assertKeyedTagMatches } from './assertions';
 
 
 /**
@@ -86,7 +70,7 @@ var alignWithDOM = function(nodeName, key, statics) {
     // should be created
     if (existingNode) {
       if (process.env.NODE_ENV !== 'production') {
-        assertKeyedTagMatches(existingNode, nodeName, key);
+        assertKeyedTagMatches(getData(existingNode).nodeName, nodeName, key);
       }
 
       matchingNode = existingNode;

--- a/src/assertions.js
+++ b/src/assertions.js
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2015 The Incremental DOM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+  * Keeps track whether or not we are in an attributes declaration (after
+  * elementOpenStart, but before elementOpenEnd).
+  * @type {boolean}
+  */
+var inAttributes = false;
+
+
+/**
+ * Makes sure that there is a current patch context.
+ * @param {*} context
+ */
+var assertInPatch = function(context) {
+  if (!context) {
+    throw new Error('Cannot call currentElement() unless in patch');
+  }
+};
+
+
+/**
+* Makes sure that keyed Element matches the tag name provided.
+* @param {!Element} nodeName The nodeName of the node that is being matched.
+* @param {string=} tag The tag name of the Element.
+* @param {?string=} key The key of the Element.
+*/
+var assertKeyedTagMatches = function(nodeName, tag, key) {
+  if (nodeName !== tag) {
+    throw new Error('Was expecting node with key "' + key + '" to be a ' +
+        tag + ', not a ' + nodeName + '.');
+  }
+};
+
+
+/**
+ * Makes sure that a patch closes every node that it opened.
+ * @param {!Node} openElement
+ * @param {!Node|!DocumentFragment} root
+ */
+var assertNoUnclosedTags = function(openElement, root) {
+  if (openElement === root) {
+    return;
+  }
+
+  var openTags = [];
+  while (openElement && openElement !== root) {
+    openTags.push(openElement.nodeName.toLowerCase());
+    openElement = openElement.parentNode;
+  }
+
+  throw new Error('One or more tags were not closed:\n' +
+      openTags.join('\n'));
+};
+
+
+/**
+ * Makes sure that the caller is not where attributes are expected.
+ * @param {string} functionName
+ */
+var assertNotInAttributes = function(functionName) {
+  if (inAttributes) {
+    throw new Error(functionName + '() may not be called between ' +
+        'elementOpenStart() and elementOpenEnd().');
+  }
+};
+
+
+/**
+ * Makes sure that the caller is where attributes are expected.
+ * @param {string} functionName
+ */
+var assertInAttributes = function(functionName) {
+  if (!inAttributes) {
+    throw new Error(functionName + '() must be called after ' +
+        'elementOpenStart().');
+  }
+};
+
+
+/**
+  * Makes sure that placeholders have a key specified. Otherwise, conditional
+  * placeholders and conditional elements next to placeholders will cause
+  * placeholder elements to be re-used as non-placeholders and vice versa.
+  * @param {string} key
+  */
+var assertPlaceholderKeySpecified = function(key) {
+  if (!key) {
+    throw new Error('Placeholder elements must have a key specified.');
+  }
+};
+
+
+/**
+  * Makes sure that tags are correctly nested.
+  * @param {string} nodeName
+  * @param {string} tag
+  */
+var assertCloseMatchesOpenTag = function(nodeName, tag) {
+  if (nodeName !== tag) {
+    throw new Error('Received a call to close ' + tag + ' but ' +
+        nodeName + ' was open.');
+  }
+};
+
+
+/**
+ * Updates the state to being in an attribute declaration.
+ * @param {boolean} value
+ */
+var setInAttributes = function(value) {
+  inAttributes = value;
+};
+
+
+/** */
+export {
+  assertInPatch,
+  assertKeyedTagMatches,
+  assertNoUnclosedTags,
+  assertNotInAttributes,
+  assertInAttributes,
+  assertPlaceholderKeySpecified,
+  assertCloseMatchesOpenTag,
+  setInAttributes
+};

--- a/src/context.js
+++ b/src/context.js
@@ -16,6 +16,7 @@
 
 import { TreeWalker } from './tree_walker';
 import { notifications } from './notifications';
+import { assertInPatch } from './assertions';
 
 
 /**
@@ -127,8 +128,8 @@ var getContext = function() {
  * @return {!Node}
  */
 var currentElement = function() {
-  if (process.env.NODE_ENV !== 'production' && !context) {
-    throw new Error('Cannot call currentElement() while not in patch.');
+  if (process.env.NODE_ENV !== 'production') {
+    assertInPatch(context);
   }
   return context.walker.currentParent;
 };

--- a/src/context.js
+++ b/src/context.js
@@ -97,9 +97,11 @@ var context;
 /**
  * Enters a new patch context.
  * @param {!Element|!DocumentFragment} node
+ * @return {!Context}
  */
 var enterContext = function(node) {
   context = new Context(node, context);
+  return context;
 };
 
 

--- a/src/patch.js
+++ b/src/patch.js
@@ -25,25 +25,7 @@ import {
 } from './context';
 import { clearUnvisitedDOM } from './alignment';
 import { notifications } from './notifications';
-
-
-if (process.env.NODE_ENV !== 'production') {
-  var assertNoUnclosedTags = function(root) {
-    var openElement = getContext().walker.currentNode;
-    if (openElement === root) {
-      return;
-    }
-
-    var openTags = [];
-    while (openElement && openElement !== root) {
-      openTags.push(openElement.nodeName.toLowerCase());
-      openElement = openElement.parentNode;
-    }
-
-    throw new Error('One or more tags were not closed:\n' +
-        openTags.join('\n'));
-  };
-}
+import { assertNoUnclosedTags } from './assertions';
 
 
 /**
@@ -65,7 +47,7 @@ var patch = function(node, fn, data) {
   clearUnvisitedDOM(node);
 
   if (process.env.NODE_ENV !== 'production') {
-    assertNoUnclosedTags(node);
+    assertNoUnclosedTags(context.walker.currentNode, node);
   }
 
   context.notifyChanges();

--- a/src/patch.js
+++ b/src/patch.js
@@ -25,7 +25,10 @@ import {
 } from './context';
 import { clearUnvisitedDOM } from './alignment';
 import { notifications } from './notifications';
-import { assertNoUnclosedTags } from './assertions';
+import {
+  assertNoUnclosedTags,
+  setInAttributes
+} from './assertions';
 
 
 /**
@@ -40,6 +43,9 @@ import { assertNoUnclosedTags } from './assertions';
  */
 var patch = function(node, fn, data) {
   var context = enterContext(node);
+  if (process.env.NODE_ENV !== 'production') {
+    setInAttributes(false);
+  }
 
   firstChild();
   fn(data);

--- a/src/patch.js
+++ b/src/patch.js
@@ -20,7 +20,6 @@ import {
 } from './traversal';
 import { TreeWalker } from './tree_walker';
 import {
-    getContext,
     enterContext,
     restoreContext
 } from './context';
@@ -58,7 +57,7 @@ if (process.env.NODE_ENV !== 'production') {
  * @template T
  */
 var patch = function(node, fn, data) {
-  enterContext(node);
+  var context = enterContext(node);
 
   firstChild();
   fn(data);
@@ -69,7 +68,7 @@ var patch = function(node, fn, data) {
     assertNoUnclosedTags(node);
   }
 
-  getContext().notifyChanges();
+  context.notifyChanges();
   restoreContext();
 };
 


### PR DESCRIPTION
- Extracts assertions into their own module
  - So `patch` and `virtual_element` modules could share `inAttributes` state
  - It's still eliminated when minified, I checked.