### PR TITLE
Close over inAttributes state

### DIFF
--- a/src/assertions.js
+++ b/src/assertions.js
@@ -131,11 +131,20 @@ var assertCloseMatchesOpenTag = function(nodeName, tag) {
 
 
 /**
- * Updates the state to being in an attribute declaration.
+ * Updates the state of being in an attribute declaration.
  * @param {boolean} value
  */
 var setInAttributes = function(value) {
   inAttributes = value;
+};
+
+
+/**
+ * Returns the state of being in an attribute declaration.
+ * @return {boolean}
+ */
+var getInAttributes = function() {
+  return inAttributes;
 };
 
 
@@ -149,5 +158,6 @@ export {
   assertPlaceholderKeySpecified,
   assertCloseMatchesOpenTag,
   assertVirtualAttributesClosed,
-  setInAttributes
+  setInAttributes,
+  getInAttributes
 };

--- a/src/core.js
+++ b/src/core.js
@@ -28,7 +28,8 @@ import {
   assertNoUnclosedTags,
   assertNotInAttributes,
   assertVirtualAttributesClosed,
-  setInAttributes
+  setInAttributes,
+  getInAttributes
 } from './assertions';
 import { notifications } from './notifications';
 
@@ -78,6 +79,7 @@ var patch = function(node, fn, data) {
   previousNode = null;
 
   if (process.env.NODE_ENV !== 'production') {
+    var prevInAttributes = getInAttributes();
     setInAttributes(false);
   }
 
@@ -88,6 +90,7 @@ var patch = function(node, fn, data) {
   if (process.env.NODE_ENV !== 'production') {
     assertVirtualAttributesClosed();
     assertNoUnclosedTags(previousNode, node);
+    setInAttributes(prevInAttributes);
   }
 
   context.notifyChanges();


### PR DESCRIPTION
Our assertions should be consistent, even if you were to open another patch inside a virtual attributes element.