### PR TITLE
Fixed broken link in gh-pages content

### DIFF
--- a/content/app-content/app-content.html
+++ b/content/app-content/app-content.html
@@ -69,7 +69,7 @@
       <h2 is="h2-with-link" id="installation">Installation</h2>
       <section>
         <p>
-          See <a href="http://google.github.io/incremental-dom/">our Github</a>.
+          See <a href="https://github.com/google/incremental-dom">our Github</a>.
         </p>
         <p>
         </p>


### PR DESCRIPTION
"See our GitHub" should point to the GitHub repo IMHO.