### PR TITLE
Remove the attributes cache

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -45,7 +45,9 @@ var applyAttr = function(el, name, value) {
  * @param {*} value The property's value.
  */
 var applyProp = function(el, name, value) {
-  el[name] = value;
+  if (el[name] !== value) {
+    el[name] = value;
+  }
 };
 
 
@@ -99,17 +101,20 @@ var applyAttributeTyped = function(el, name, value) {
  * @param {*} value The attribute's value.
  */
 var updateAttribute = function(el, name, value) {
-  var data = getData(el);
-  var attrs = data.attrs;
-
-  if (attrs[name] === value) {
-    return;
-  }
-
   var mutator = attributes[name] || attributes[symbols.default];
   mutator(el, name, value);
+};
 
-  attrs[name] = value;
+
+/**
+ * Sets this element as a placeholder through attributes.
+ * @param {!Element} el
+ * @param {string} name The attribute's name.
+ * @param {*} value The attribute's value.
+ */
+var applyPlaceholder = function(el, name, value) {
+  var data = getData(el);
+  data.placeholder = !!value;
 };
 
 
@@ -123,7 +128,7 @@ var attributes = createMap();
 // have a specific mutator.
 attributes[symbols.default] = applyAttributeTyped;
 
-attributes[symbols.placeholder] = function() {};
+attributes[symbols.placeholder] = applyPlaceholder;
 
 attributes['style'] = applyStyle;
 

--- a/src/core.js
+++ b/src/core.js
@@ -21,7 +21,6 @@ import {
 } from './nodes';
 import { getData } from './node_data';
 import { Context } from './context';
-import { symbols } from './symbols';
 import {
   assertInPatch,
   assertKeyedTagMatches,
@@ -185,7 +184,7 @@ var clearUnvisitedDOM = function() {
     return;
   }
 
-  if (data.attrs[symbols.placeholder] && node !== root) {
+  if (data.placeholder && node !== root) {
     return;
   }
 

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -25,10 +25,23 @@ import { createMap } from './util';
  */
 function NodeData(nodeName, key) {
   /**
-   * The attributes and their values.
-   * @const
+   * The node name for this node.
+   * @const {string}
    */
-  this.attrs = createMap();
+  this.nodeName = nodeName;
+
+  /**
+   * The key used to identify this node, used to preserve DOM nodes when they
+   * move within their parent.
+   * @const {?string}
+   */
+  this.key = key;
+
+  /**
+   * The attributes and their values.
+   * @type {boolean}
+   */
+  this.placeholder = false;
 
   /**
    * An array of attribute name/value pairs, used for quickly diffing the
@@ -45,29 +58,16 @@ function NodeData(nodeName, key) {
   this.newAttrs = createMap();
 
   /**
-   * The key used to identify this node, used to preserve DOM nodes when they
-   * move within their parent.
-   * @const
-   */
-  this.key = key;
-
-  /**
    * Keeps track of children within this node by their key.
-   * {?Object<string, !Element>}
+   * @type {?Object<string, !Element>}
    */
   this.keyMap = null;
 
   /**
    * Whether or not the keyMap is currently valid.
-   * {boolean}
+   * @type {boolean}
    */
   this.keyMapValid = true;
-
-  /**
-   * The node name for this node.
-   * @const {string}
-   */
-  this.nodeName = nodeName;
 
   /**
    * @type {?string}


### PR DESCRIPTION
Caching can be handled by custom attribute mutators, if needed.

| Browser | Test | Branch | Result (ms) |
| --- | --- | --- | --- |
| Chrome | Creation | Master | 2.6 |
| Chrome | Creation | attributes | 2.0 |
| Chrome | Selection | Master | .22 |
| Chrome | Selection | attributes | .23 |
| FireFox | Creation | Master | 6.16 |
| FireFox | Creation | attributes | 5.57 |
| FireFox | Selection | Master | .44 |
| FireFox | Selection | attributes | .43 |
| Safari | Creation | Master | 1.7 |
| Safari | Creation | attributes | 1.52 |
| Safari | Selection | Master | .45 |
| Safari | Selection | attributes | .43 |