### PR TITLE
Assert skip

### DIFF
--- a/src/assertions.js
+++ b/src/assertions.js
@@ -167,18 +167,24 @@ var assertNoChildrenDeclaredYet = function(functionName, previousNode) {
 /**
  * Updates the state of being in an attribute declaration.
  * @param {boolean} value
+ * @return {boolean} the previous value.
  */
 var setInAttributes = function(value) {
+  var previous = inAttributes;
   inAttributes = value;
+  return previous;
 };
 
 
 /**
  * Updates the state of being in a skip element.
  * @param {boolean} value
+ * @return {boolean} the previous value.
  */
 var setInSkip = function(value) {
+  var previous = inSkip;
   inSkip = value;
+  return previous;
 };
 
 

--- a/src/assertions.js
+++ b/src/assertions.js
@@ -24,6 +24,14 @@ var inAttributes = false;
 
 
 /**
+  * Keeps track whether or not we are in an element that should not have its
+  * children cleared.
+  * @type {boolean}
+  */
+var inSkip = false;
+
+
+/**
  * Makes sure that there is a current patch context.
  * @param {*} context
  */
@@ -77,6 +85,18 @@ var assertNotInAttributes = function(functionName) {
   if (inAttributes) {
     throw new Error(functionName + '() may not be called between ' +
         'elementOpenStart() and elementOpenEnd().');
+  }
+};
+
+
+/**
+ * Makes sure that the caller is not inside an element that has declared skip.
+ * @param {string} functionName
+ */
+var assertNotInSkip = function(functionName) {
+  if (inSkip) {
+    throw new Error(functionName + '() may not be called inside an element ' +
+        'that has called skip().');
   }
 };
 
@@ -153,6 +173,15 @@ var setInAttributes = function(value) {
 };
 
 
+/**
+ * Updates the state of being in a skip element.
+ * @param {boolean} value
+ */
+var setInSkip = function(value) {
+  inSkip = value;
+};
+
+
 /** */
 export {
   assertInPatch,
@@ -164,5 +193,7 @@ export {
   assertCloseMatchesOpenTag,
   assertVirtualAttributesClosed,
   assertNoChildrenDeclaredYet,
-  setInAttributes
+  assertNotInSkip,
+  setInAttributes,
+  setInSkip
 };

--- a/src/assertions.js
+++ b/src/assertions.js
@@ -131,7 +131,21 @@ var assertCloseMatchesOpenTag = function(nodeName, tag) {
 
 
 /**
- * Updates the state to being in an attribute declaration.
+ * Makes sure that no children elements have been declared yet in the current
+ * element.
+ * @param {string} functionName
+ * @param {?Node} previousNode
+ */
+var assertNoChildrenDeclaredYet = function(functionName, previousNode) {
+  if (previousNode !== null) {
+    throw new Error(functionName + '() must come before any child ' +
+        'declarations inside the current element.');
+  }
+};
+
+
+/**
+ * Updates the state of being in an attribute declaration.
  * @param {boolean} value
  */
 var setInAttributes = function(value) {
@@ -149,5 +163,6 @@ export {
   assertPlaceholderKeySpecified,
   assertCloseMatchesOpenTag,
   assertVirtualAttributesClosed,
+  assertNoChildrenDeclaredYet,
   setInAttributes
 };

--- a/src/core.js
+++ b/src/core.js
@@ -28,6 +28,7 @@ import {
   assertNoUnclosedTags,
   assertNotInAttributes,
   assertVirtualAttributesClosed,
+  assertNoChildrenDeclaredYet,
   setInAttributes
 } from './assertions';
 import { notifications } from './notifications';
@@ -309,6 +310,9 @@ var currentElement = function() {
  * clearing out the children.
  */
 var skip = function() {
+  if (process.env.NODE_ENV !== 'production') {
+    assertNoChildrenDeclaredYet('skip', previousNode);
+  }
   previousNode = currentParent.lastChild;
 };
 

--- a/src/core.js
+++ b/src/core.js
@@ -29,7 +29,8 @@ import {
   assertNotInAttributes,
   assertVirtualAttributesClosed,
   assertNoChildrenDeclaredYet,
-  setInAttributes
+  setInAttributes,
+  setInSkip
 } from './assertions';
 import { notifications } from './notifications';
 
@@ -80,6 +81,7 @@ var patch = function(node, fn, data) {
 
   if (process.env.NODE_ENV !== 'production') {
     setInAttributes(false);
+    setInSkip(false);
   }
 
   enterNode();
@@ -274,6 +276,10 @@ var elementOpen = function(tag, key, statics) {
  * @return {!Element} The corresponding Element.
  */
 var elementClose = function() {
+  if (process.env.NODE_ENV !== 'production') {
+    setInSkip(false);
+  }
+
   exitNode();
   return /** @type {!Element} */(previousNode);
 };
@@ -312,6 +318,7 @@ var currentElement = function() {
 var skip = function() {
   if (process.env.NODE_ENV !== 'production') {
     assertNoChildrenDeclaredYet('skip', previousNode);
+    setInSkip(true);
   }
   previousNode = currentParent.lastChild;
 };

--- a/src/core.js
+++ b/src/core.js
@@ -80,8 +80,8 @@ var patch = function(node, fn, data) {
   previousNode = null;
 
   if (process.env.NODE_ENV !== 'production') {
-    setInAttributes(false);
-    setInSkip(false);
+    var previousInAttributes = setInAttributes(false);
+    var previousInSkip = setInSkip(false);
   }
 
   enterNode();
@@ -91,6 +91,8 @@ var patch = function(node, fn, data) {
   if (process.env.NODE_ENV !== 'production') {
     assertVirtualAttributesClosed();
     assertNoUnclosedTags(previousNode, node);
+    setInAttributes(previousInAttributes);
+    setInSkip(previousInSkip);
   }
 
   context.notifyChanges();

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -26,6 +26,7 @@ import { getData } from './node_data';
 import { symbols } from './symbols';
 import {
   assertNotInAttributes,
+  assertNotInSkip,
   assertInAttributes,
   assertPlaceholderKeySpecified,
   assertCloseMatchesOpenTag,
@@ -64,6 +65,7 @@ var argsBuilder = [];
 var elementOpen = function(tag, key, statics, var_args) {
   if (process.env.NODE_ENV !== 'production') {
     assertNotInAttributes('elementOpen');
+    assertNotInSkip('elementOpen');
   }
 
   var node = coreElementOpen(tag, key, statics);
@@ -255,6 +257,7 @@ var elementPlaceholder = function(tag, key, statics, var_args) {
 var text = function(value, var_args) {
   if (process.env.NODE_ENV !== 'production') {
     assertNotInAttributes('text');
+    assertNotInSkip('text');
   }
 
   var node = coreText();

--- a/test/functional/skip.js
+++ b/test/functional/skip.js
@@ -18,6 +18,7 @@ import {
     patch,
     elementOpen,
     elementClose,
+    elementVoid,
     skip,
     text
 } from '../../index';
@@ -52,5 +53,41 @@ describe('skip', () => {
     expect(container.textContent).to.equal('some text');
   });
 
+  it('should throw if an element is declared after skipping', () => {
+    expect(() => {
+      patch(container, () => {
+        skip();
+        elementOpen('div');
+        elementClose('div');
+      });
+    }).to.throw('elementOpen() may not be called inside an element that has called skip().');
+  });
+
+  it('should throw if a text is declared after skipping', () => {
+    expect(() => {
+      patch(container, () => {
+        skip();
+        text('text');
+      });
+    }).to.throw('text() may not be called inside an element that has called skip().');
+  });
+
+  it('should throw skip is called after declaring an element', () => {
+    expect(() => {
+      patch(container, () => {
+        elementVoid('div');
+        skip();
+      });
+    }).to.throw('skip() must come before any child declarations inside the current element.');
+  });
+
+  it('should throw skip is called after declaring a text', () => {
+    expect(() => {
+      patch(container, () => {
+        text('text');
+        skip();
+      });
+    }).to.throw('skip() must come before any child declarations inside the current element.');
+  });
 });
 


### PR DESCRIPTION
Asserts that no children are declared inside the an element that calls `skip`. Re: #182