### PR TITLE
virtual_elements.js/text slice arguments in local scope before call

### DIFF
--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -268,7 +268,11 @@ var text = function(value, var_args) {
 
     var formatted = value;
     for (var i = 1; i < arguments.length; i += 1) {
-      formatted = arguments[i](formatted);
+      /*
+       * The parenthesis syntax prevents leaking the arguments object.
+       * https://github.com/google/incremental-dom/pull/204#issuecomment-178223574
+       */
+      formatted = (0, arguments[i])(formatted);
     }
 
     node.data = formatted;


### PR DESCRIPTION
I know the library is not yet in optimization stage, but this one may be worth looking into already as the fix is commonly used and the de-optimized function is called many times during a single patch.

![idom-text-deopt](https://cloud.githubusercontent.com/assets/677599/12722811/91837882-c8fe-11e5-8aff-0c91ccd6e7e9.png)
