### PR TITLE
Fix text function not being optimized.

### DIFF
--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -269,10 +269,11 @@ var text = function(value, var_args) {
     var formatted = value;
     for (var i = 1; i < arguments.length; i += 1) {
       /*
-       * The parenthesis syntax prevents leaking the arguments object.
+       * Call the formatter function directly to prevent leaking arguments.
        * https://github.com/google/incremental-dom/pull/204#issuecomment-178223574
        */
-      formatted = (0, arguments[i])(formatted);
+      var fn = arguments[i];
+      formatted = fn(formatted);
     }
 
     node.data = formatted;

--- a/test/functional/formatters.js
+++ b/test/functional/formatters.js
@@ -82,5 +82,12 @@ describe('formatters', () => {
       expect(stub).to.have.been.calledTwice;
     });
   });
+
+  it('should not leak the arguments object', () => {
+    var stub = sinon.stub().returns('value');
+    patch(container, () => text('value', stub));
+
+    expect(stub).to.have.been.calledOn(undefined);
+  });
 });
 


### PR DESCRIPTION
This fixes the issue brought up in #204, but was not actually fixed by the change.

It seems like uglify optimizes the previous change out.

@paolocaminiti @jridgewell Any thoughts?