### PR TITLE
Add a warning for symbol.placeholder being deprecated.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -239,6 +239,10 @@ var clearUnvisitedDOM = function() {
   }
 
   if (data.attrs[symbols.placeholder] && node !== root) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('symbols.placeholder will be removed in Incremental DOM 0.5'
+          + ' use skip() instead');
+    }
     return;
   }
 

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -237,6 +237,8 @@ var elementVoid = function(tag, key, statics, var_args) {
 var elementPlaceholder = function(tag, key, statics, var_args) {
   if (process.env.NODE_ENV !== 'production') {
     assertPlaceholderKeySpecified(key);
+    console.warn('elementPlaceholder will be removed in Incremental DOM 0.5'
+        + ' use skip() instead');
   }
 
   elementOpen.apply(null, arguments);


### PR DESCRIPTION
Somewhat debating just removing symbols.placeholder immediately. It was never documented and it isn't likely many people are using it anyway.