### PR TITLE
Avoid Live HTMLCollection

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -93,16 +93,16 @@ const createText = function(doc) {
  */
 const createKeyMap = function(el) {
   const map = createMap();
-  const children = el.children;
-  const count = children.length;
+  let child = el.firstElementChild;
 
-  for (let i = 0; i < count; i += 1) {
-    const child = children[i];
+  while (child) {
     const key = getData(child).key;
 
     if (key) {
       map[key] = child;
     }
+
+    child = child.nextElementSibling;
   }
 
   return map;


### PR DESCRIPTION
Use `next` syntax to avoid creating a live `HTMLCollection` instance,
which is [_really_ slow](http://jsperf.com/nextsibling-vs-childnodes-increment/6).