### PR TITLE
Add support for namespaced attributes on SVG Elements

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -22,8 +22,7 @@ import {
 } from './util';
 
 /**
- * Namespace reference map for attributes on special non-HTML elements
- * Associates each attribute name with the required namespace
+ * Reference map for SVG namespaced attributes
  */
 const xlinkNS = 'http://www.w3.org/1999/xlink';
 const xmlNS = 'http://www.w3.org/XML/1998/namespace';
@@ -43,8 +42,7 @@ const attributeNSMap = {
 /**
  * Applies an attribute or property to a given Element. If the value is null
  * or undefined, it is removed from the Element. Otherwise, the value is set
- * as an attribute. If the element is not in the HTML namespace (eg SVG),
- * the attribute is set in the appropriate namespace.
+ * as an attribute.
  * @param {!Element} el
  * @param {string} name The attribute's name.
  * @param {?(boolean|number|string)=} value The attribute's value.
@@ -53,8 +51,8 @@ const applyAttr = function(el, name, value) {
   if (value == null) {
     el.removeAttribute(name);
   } else {
-    if (el.namespaceURI !== 'http://www.w3.org/1999/xhtml') {
-      const attrNS = attributeNSMap[name] || null;
+    let attrNS = attributeNSMap[name];
+    if (attrNS) {
       el.setAttributeNS(attrNS, name, value);
     } else {
       el.setAttribute(name, value);

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -21,11 +21,30 @@ import {
   has
 } from './util';
 
+/**
+ * Namespace reference map for attributes on special non-HTML elements
+ * Associates each attribute name with the required namespace
+ */
+const xlinkNS = 'http://www.w3.org/1999/xlink';
+const xmlNS = 'http://www.w3.org/XML/1998/namespace';
+const attributeNSMap = {
+  'xlink:actuate': xlinkNS,
+  'xlink:arcrole': xlinkNS,
+  'xlink:href': xlinkNS,
+  'xlink:role': xlinkNS,
+  'xlink:show': xlinkNS,
+  'xlink:title': xlinkNS,
+  'xlink:type': xlinkNS,
+  'xml:base': xmlNS,
+  'xml:lang': xmlNS,
+  'xml:space': xmlNS
+};
 
 /**
  * Applies an attribute or property to a given Element. If the value is null
  * or undefined, it is removed from the Element. Otherwise, the value is set
- * as an attribute.
+ * as an attribute. If the element is not in the HTML namespace (eg SVG),
+ * the attribute is set in the appropriate namespace.
  * @param {!Element} el
  * @param {string} name The attribute's name.
  * @param {?(boolean|number|string)=} value The attribute's value.
@@ -34,15 +53,9 @@ const applyAttr = function(el, name, value) {
   if (value == null) {
     el.removeAttribute(name);
   } else {
-    const svgns = 'http://www.w3.org/2000/svg';
-
-    if (el.namespaceURI === svgns) {
-      var ns = null;
-      if (name === 'xlink:href') {
-        ns = 'http://www.w3.org/1999/xlink';
-        name = 'href';
-      }
-      el.setAttributeNS(ns, name, value);
+    if (el.namespaceURI !== 'http://www.w3.org/1999/xhtml') {
+      const attrNS = attributeNSMap[name] || null;
+      el.setAttributeNS(attrNS, name, value);
     } else {
       el.setAttribute(name, value);
     }

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -34,7 +34,18 @@ const applyAttr = function(el, name, value) {
   if (value == null) {
     el.removeAttribute(name);
   } else {
-    el.setAttribute(name, value);
+    const svgns = 'http://www.w3.org/2000/svg';
+
+    if (el.namespaceURI === svgns) {
+      var ns = null;
+      if (name === 'xlink:href') {
+        ns = 'http://www.w3.org/1999/xlink';
+        name = 'href';
+      }
+      el.setAttributeNS(ns, name, value);
+    } else {
+      el.setAttribute(name, value);
+    }
   }
 };
 

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -51,7 +51,7 @@ const applyAttr = function(el, name, value) {
   if (value == null) {
     el.removeAttribute(name);
   } else {
-    let attrNS = attributeNSMap[name];
+    const attrNS = attributeNSMap[name];
     if (attrNS) {
       el.setAttributeNS(attrNS, name, value);
     } else {

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -16,6 +16,7 @@
 
 import {
   patch,
+  elementOpen,
   elementOpenStart,
   elementOpenEnd,
   attr,
@@ -223,6 +224,17 @@ describe('attribute updates', () => {
 
       expect(el.getAttribute('class')).to.equal('foo');
     });
+    
+    it('should apply the correct namespace for namespaced SVG attributes', function(){
+      patch(container, () => {
+        elementOpen('svg');
+        elementVoid('image', null, null,
+            'xlink:href', '#foo');
+        elementClose('svg');
+      });
+      const el = container.childNodes[0].childNodes[0];
+      expect(el.getAttributeNS('http://www.w3.org/1999/xlink', 'href')).to.equal('#foo');
+    })
   });
 });
 

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -234,7 +234,23 @@ describe('attribute updates', () => {
       });
       const el = container.childNodes[0].childNodes[0];
       expect(el.getAttributeNS('http://www.w3.org/1999/xlink', 'href')).to.equal('#foo');
-    })
+    });
+
+    it('should remove namespaced SVG attributes', function(){
+      patch(container, () => {
+        elementOpen('svg');
+        elementVoid('image', null, null,
+            'xlink:href', '#foo');
+        elementClose('svg');
+      });
+      patch(container, () => {
+        elementOpen('svg');
+        elementVoid('image', null, null);
+        elementClose('svg');
+      });
+      const el = container.childNodes[0].childNodes[0];
+      expect(el.getAttributeNS('http://www.w3.org/1999/xlink', 'href')).to.equal(null);
+    });
   });
 });
 

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -249,7 +249,7 @@ describe('attribute updates', () => {
         elementClose('svg');
       });
       const el = container.childNodes[0].childNodes[0];
-      expect(el.getAttributeNS('http://www.w3.org/1999/xlink', 'href')).to.equal(null);
+      expect(el.hasAttributeNS('http://www.w3.org/1999/xlink', 'href')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
The issue with attributes on SVG elements was referenced in #21 but remains unfixed. Namespaced attributes are required for SVG icons and nodes that use xlink:href, two common use cases of SVGs on the web.

This pull request checks if the Element was created the SVG namespace (PR #26) and if so switches from setAttribute() to setAttributeNS(). It also will set "xlink:href" attributes in the proper namespace.