### PR TITLE
Use createMap instead of an object literal

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -26,18 +26,17 @@ import {
  */
 const xlinkNS = 'http://www.w3.org/1999/xlink';
 const xmlNS = 'http://www.w3.org/XML/1998/namespace';
-const attributeNSMap = {
-  'xlink:actuate': xlinkNS,
-  'xlink:arcrole': xlinkNS,
-  'xlink:href': xlinkNS,
-  'xlink:role': xlinkNS,
-  'xlink:show': xlinkNS,
-  'xlink:title': xlinkNS,
-  'xlink:type': xlinkNS,
-  'xml:base': xmlNS,
-  'xml:lang': xmlNS,
-  'xml:space': xmlNS
-};
+const attributeNSMap = createMap();
+attributeNSMap['xlink:actuate'] = xlinkNS;
+attributeNSMap['xlink:arcrole'] = xlinkNS;
+attributeNSMap['xlink:href'] = xlinkNS;
+attributeNSMap['xlink:role'] = xlinkNS;
+attributeNSMap['xlink:show'] = xlinkNS;
+attributeNSMap['xlink:title'] = xlinkNS;
+attributeNSMap['xlink:type'] = xlinkNS;
+attributeNSMap['xml:base'] = xmlNS;
+attributeNSMap['xml:lang'] = xmlNS;
+attributeNSMap['xml:space'] = xmlNS;
 
 /**
  * Applies an attribute or property to a given Element. If the value is null


### PR DESCRIPTION
Update to #222 
Remove prototype properties of the attribute namespace map