### PR TITLE
Simplify attribute namespace logic.

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -21,23 +21,21 @@ import {
   has
 } from './util';
 
+
 /**
- * Reference map for SVG namespaced attributes
+ * @param {string} name
+ * @return {?string} The namespace to use for the attribute.
  */
-const xlinkNS = 'http://www.w3.org/1999/xlink';
-const xmlNS = 'http://www.w3.org/XML/1998/namespace';
-const attributeNSMap = {
-  'xlink:actuate': xlinkNS,
-  'xlink:arcrole': xlinkNS,
-  'xlink:href': xlinkNS,
-  'xlink:role': xlinkNS,
-  'xlink:show': xlinkNS,
-  'xlink:title': xlinkNS,
-  'xlink:type': xlinkNS,
-  'xml:base': xmlNS,
-  'xml:lang': xmlNS,
-  'xml:space': xmlNS
+const getNamespace = function(name) {
+  if (name.lastIndexOf('xml:', 0) === 0) {
+    return 'http://www.w3.org/XML/1998/namespace';
+  }
+
+  if (name.lastIndexOf('xlink:', 0) === 0) {
+    return 'http://www.w3.org/1999/xlink';
+  }
 };
+
 
 /**
  * Applies an attribute or property to a given Element. If the value is null
@@ -51,7 +49,7 @@ const applyAttr = function(el, name, value) {
   if (value == null) {
     el.removeAttribute(name);
   } else {
-    const attrNS = attributeNSMap[name];
+    const attrNS = getNamespace(name);
     if (attrNS) {
       el.setAttributeNS(attrNS, name, value);
     } else {


### PR DESCRIPTION
Using `lastIndexOf` for determining the namespace is more compact and marginally faster than using a map lookup.

See https://github.com/sparhami/indexof-map-benchmark