### PR TITLE
Fix a missing return in getNamespace() in src/attributes.js

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -24,7 +24,7 @@ import {
 
 /**
  * @param {string} name
- * @return {?string} The namespace to use for the attribute.
+ * @return {string|undefined} The namespace to use for the attribute.
  */
 const getNamespace = function(name) {
   if (name.lastIndexOf('xml:', 0) === 0) {


### PR DESCRIPTION
This was caught by Closure Compiler.