### PR TITLE
Run Closure Compiler's checks during dist build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ var del = require('del');
 var source = require('vinyl-source-stream');
 var buffer = require('vinyl-buffer');
 var rollup = require('rollup-stream');
+var closureCompiler = require('google-closure-compiler').gulp();
 var babel = require('rollup-plugin-babel');
 var uglify = require('rollup-plugin-uglify');
 var gjslint = require('gulp-gjslint');
@@ -158,9 +159,23 @@ function jsDist() {
   // change process.env.NODE_ENV. The CommonJS target could run in parallel
   // with the js and jsMin targets, but currently is not.
   return clean()
+    .then(jsClosureChecks)
     .then(jsCommonJS)
     .then(js)
     .then(jsMin);
+}
+
+function jsClosureChecks() {
+  return gulp.src([
+    'index.js',
+    './src/**/*.js'
+  ])
+  .pipe(closureCompiler({
+    checks_only: 'true',
+    externs: 'node_externs.js',
+    language_in: 'ECMASCRIPT6_STRICT',
+    warning_level: 'VERBOSE'
+  }));
 }
 
 gulp.task('clean', clean);
@@ -173,6 +188,7 @@ gulp.task('js-watch', jsWatch);
 gulp.task('js-min', jsMin);
 gulp.task('js-dist', jsDist);
 gulp.task('js-closure', jsClosure);
+gulp.task('js-closure-checks', jsClosureChecks);
 gulp.task('build', ['lint', 'unit'], js);
 gulp.task('dist', ['lint', 'unit-phantom'], jsDist);
 

--- a/node_externs.js
+++ b/node_externs.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 20l6 The Incremental DOM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @externs */
+
+/** @type {!Object} */
+var process;
+
+/** @type {*} */
+process.env;
+
+/** @type {string} */
+process.env.NODE_ENV;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-plugin-transform-inline-environment-variables": "^6.5.0",
     "chai": "^3.0.0",
     "del": "^2.0.2",
+    "google-closure-compiler": "^20160315.2.0",
     "gulp": "^3.9.0",
     "gulp-gjslint": "^0.1.4",
     "gulp-replace": "^0.5.4",

--- a/src/core.js
+++ b/src/core.js
@@ -62,7 +62,16 @@ let doc = null;
  * @template T
  */
 const patchFactory = function(run) {
-  return function(node, fn, data) {
+  /**
+   * TODO(moz): These annotations won't be necessary once we switch to Closure
+   * Compiler's new type inference. Remove these once the switch is done.
+   *
+   * @param {(!Element|!DocumentFragment)} node
+   * @param {!function(T)} fn
+   * @param {T=} data
+   * @template T
+   */
+  const f = function(node, fn, data) {
     const prevContext = context;
     const prevRoot = root;
     const prevDoc = doc;
@@ -97,6 +106,7 @@ const patchFactory = function(run) {
     currentNode = prevCurrentNode;
     currentParent = prevCurrentParent;
   };
+  return f;
 };
 
 


### PR DESCRIPTION
Adds a "js-closure-checks" task that uses Closure Compiler to
check the source code.

Closes #128.