### PR TITLE
Fix type annotations in node_externs.js

### DIFF
--- a/node_externs.js
+++ b/node_externs.js
@@ -16,10 +16,10 @@
 
 /** @externs */
 
-/** @type {!Object} */
+/** @type {?} */
 var process;
 
-/** @type {*} */
+/** @type {?} */
 process.env;
 
 /** @type {string} */


### PR DESCRIPTION
Closure Compiler's new type inference will give warnings about missing
properties. Since these shouldn't really be checked by Closure, type
them as "?".