### PR TITLE
Change import logic to import the entire subtree.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,3 +38,4 @@ export {
   applyProp
 } from './src/attributes';
 export { notifications } from './src/notifications';
+export { importNode } from './src/node_data';

--- a/src/core.js
+++ b/src/core.js
@@ -17,8 +17,6 @@
 import {
   createElement,
   createText,
-  getChild,
-  registerChild
 } from './nodes';
 import { getData } from './node_data';
 import { Context } from './context';
@@ -209,11 +207,13 @@ const alignWithDOM = function(nodeName, key, statics) {
     return;
   }
 
+  const parentData = getData(currentParent);
+  const keyMap = parentData.keyMap;
   let node;
 
   // Check to see if the node has moved within the parent.
   if (key) {
-    node = getChild(currentParent, key);
+    node = keyMap[key];
     if (node && process.env.NODE_ENV !== 'production') {
       assertKeyedTagMatches(getData(node).nodeName, nodeName, key);
     }
@@ -228,7 +228,7 @@ const alignWithDOM = function(nodeName, key, statics) {
     }
 
     if (key) {
-      registerChild(currentParent, key, node);
+      keyMap[key] = node;
     }
 
     context.markCreated(node);
@@ -240,7 +240,7 @@ const alignWithDOM = function(nodeName, key, statics) {
   // back.
   if (currentNode && getData(currentNode).key) {
     currentParent.replaceChild(node, currentNode);
-    getData(currentParent).keyMapValid = false;
+    parentData.keyMapValid = false;
   } else {
     currentParent.insertBefore(node, currentNode);
   }

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -85,75 +85,8 @@ const createText = function(doc) {
 };
 
 
-/**
- * Creates a mapping that can be used to look up children using a key.
- * @param {?Node} el
- * @return {!Object<string, !Element>} A mapping of keys to the children of the
- *     Element.
- */
-const createKeyMap = function(el) {
-  const map = createMap();
-  let child = el.firstElementChild;
-
-  while (child) {
-    const key = getData(child).key;
-
-    if (key) {
-      map[key] = child;
-    }
-
-    child = child.nextElementSibling;
-  }
-
-  return map;
-};
-
-
-/**
- * Retrieves the mapping of key to child node for a given Element, creating it
- * if necessary.
- * @param {?Node} el
- * @return {!Object<string, !Node>} A mapping of keys to child Elements
- */
-const getKeyMap = function(el) {
-  const data = getData(el);
-
-  if (!data.keyMap) {
-    data.keyMap = createKeyMap(el);
-  }
-
-  return data.keyMap;
-};
-
-
-/**
- * Retrieves a child from the parent with the given key.
- * @param {?Node} parent
- * @param {?string=} key
- * @return {?Node} The child corresponding to the key.
- */
-const getChild = function(parent, key) {
-  return key ? getKeyMap(parent)[key] : null;
-};
-
-
-/**
- * Registers an element as being a child. The parent will keep track of the
- * child using the key. The child can be retrieved using the same key using
- * getKeyMap. The provided key should be unique within the parent Element.
- * @param {?Node} parent The parent of child.
- * @param {string} key A key to identify the child with.
- * @param {!Node} child The child to register.
- */
-const registerChild = function(parent, key, child) {
-  getKeyMap(parent)[key] = child;
-};
-
-
 /** */
 export {
   createElement,
-  createText,
-  getChild,
-  registerChild
+  createText
 };

--- a/test/functional/patchInner.js
+++ b/test/functional/patchInner.js
@@ -59,13 +59,6 @@ describe('patching an element\'s children', () => {
       expect(child).to.equal(div);
     });
 
-    it('should update attributes', () => {
-      patchInner(container, render);
-      const child = container.childNodes[0];
-
-      expect(child.getAttribute('tabindex')).to.equal('0');
-    });
-
     describe('should return DOM node', () => {
       let node;
 


### PR DESCRIPTION
…le node.

- Make the importNode function available externally. This allows non-Incremental DOM managed attributes to be preserved by Incremental DOM if the first patch occurs after a DOM mutation outside of Incremental DOM.

Closes #228 