### PR TITLE
Add support for CSS custom properties.

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -70,6 +70,22 @@ const applyProp = function(el, name, value) {
 
 
 /**
+ * Applies a value to a style declaration. Supports CSS custom properties by
+ * setting properties containing a dash using CSSStyleDeclaration.setProperty.
+ * @param {CSSStyleDeclaration} style
+ * @param {!string} prop
+ * @param {*} value
+ */ 
+const setStyleValue = function(style, prop, value) {
+  if (prop.indexOf('-') >= 0) {
+    style.setProperty(prop, /** @type {string} */(value));
+  } else {
+    style[prop] = value;
+  }
+};
+
+
+/**
  * Applies a style to an Element. No vendor prefix expansion is done for
  * property names/values.
  * @param {!Element} el
@@ -87,7 +103,7 @@ const applyStyle = function(el, name, style) {
 
     for (const prop in obj) {
       if (has(obj, prop)) {
-        elStyle[prop] = obj[prop];
+        setStyleValue(elStyle, prop, obj[prop]);
       }
     }
   }

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -164,57 +164,6 @@ describe('attribute updates', () => {
     });
   });
 
-  describe('for style', () => {
-    function render(style) {
-      elementVoid('div', null, null,
-          'style', style);
-    }
-
-    it('should render with the correct style properties for objects', () => {
-      patch(container, () => render({
-        color: 'white',
-        backgroundColor: 'red'
-      }));
-      const el = container.childNodes[0];
-
-      expect(el.style.color).to.equal('white');
-      expect(el.style.backgroundColor).to.equal('red');
-    });
-
-    it('should update the correct style properties', () => {
-      patch(container, () => render({
-        color: 'white'
-      }));
-      patch(container, () => render({
-        color: 'red'
-      }));
-      const el = container.childNodes[0];
-
-      expect(el.style.color).to.equal('red');
-    });
-
-    it('should remove properties not present in the new object', () => {
-      patch(container, () => render({
-        color: 'white'
-      }));
-      patch(container, () => render({
-        backgroundColor: 'red'
-      }));
-      const el = container.childNodes[0];
-
-      expect(el.style.color).to.equal('');
-      expect(el.style.backgroundColor).to.equal('red');
-    });
-
-    it('should render with the correct style properties for strings', () => {
-      patch(container, () => render('color: white; background-color: red;'));
-      const el = container.childNodes[0];
-
-      expect(el.style.color).to.equal('white');
-      expect(el.style.backgroundColor).to.equal('red');
-    });
-  });
-
   describe('for svg elements', () => {
     it('should correctly apply the class attribute', function() {
       patch(container, () => {

--- a/test/functional/styles.js
+++ b/test/functional/styles.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2016 The Incremental DOM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  patch,
+  elementVoid,
+} from '../../index';
+
+describe('style updates', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  function browserSupportsCssCustomProperties() {
+    const style = document.createElement('div').style;
+    style.setProperty('--prop', 'value');
+    return style.getPropertyValue('--prop') === 'value';
+  }
+
+  function render(style) {
+    elementVoid('div', null, null,
+        'style', style);
+  }
+
+  it('should render with the correct style properties for objects', () => {
+    patch(container, () => render({
+      color: 'white',
+      backgroundColor: 'red'
+    }));
+    const el = container.childNodes[0];
+
+    expect(el.style.color).to.equal('white');
+    expect(el.style.backgroundColor).to.equal('red');
+  });
+
+  if (browserSupportsCssCustomProperties()) {
+    it('should apply custom properties', () => {
+      patch(container, () => render({
+        '--some-var': 'blue'
+      }));
+      const el = container.childNodes[0];
+
+      expect(el.style.getPropertyValue('--some-var')).to.equal('blue');
+    });
+  }
+
+  it('should handle dashes in property names', () => {
+    patch(container, () => render({
+      'background-color': 'red'
+    }));
+    const el = container.childNodes[0];
+
+    expect(el.style.backgroundColor).to.equal('red');
+  });
+
+  it('should update the correct style properties', () => {
+    patch(container, () => render({
+      color: 'white'
+    }));
+    patch(container, () => render({
+      color: 'red'
+    }));
+    const el = container.childNodes[0];
+
+    expect(el.style.color).to.equal('red');
+  });
+
+  it('should remove properties not present in the new object', () => {
+    patch(container, () => render({
+      color: 'white'
+    }));
+    patch(container, () => render({
+      backgroundColor: 'red'
+    }));
+    const el = container.childNodes[0];
+
+    expect(el.style.color).to.equal('');
+    expect(el.style.backgroundColor).to.equal('red');
+  });
+
+  it('should render with the correct style properties for strings', () => {
+    patch(container, () => render('color: white; background-color: red;'));
+    const el = container.childNodes[0];
+
+    expect(el.style.color).to.equal('white');
+    expect(el.style.backgroundColor).to.equal('red');
+  });
+});
+


### PR DESCRIPTION
- For consistency, support dashes in all style property names, not just those starting with `--`