### PR TITLE
Preserve focus for elements with a key specified.

### DIFF
--- a/conf/karma.conf.js
+++ b/conf/karma.conf.js
@@ -24,7 +24,7 @@ module.exports = function(config) {
     basePath: '../',
 
     files: [
-      'test/**/*.js'
+      'test/functional/**/*.js'
     ],
 
     preprocessors: {

--- a/src/dom_util.js
+++ b/src/dom_util.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2016 The Incremental DOM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * @return True if the node the root of a document, false otherwise.
+ */
+const isDocumentRoot = function(node) {
+  // For ShadowRoots, check if they are a DocumentFragment instead of if they
+  // are a ShadowRoot so that this can work in 'use strict' if ShadowRoots are
+  // not supported.
+  return node instanceof Document || node instanceof DocumentFragment;
+};
+
+
+/**
+ * @param {!Node} node The node to start at, inclusive.
+ * @param {?Node} root The root ancestor to get until, exclusive.
+ * @return {!Array<!Node>} The ancestry of DOM nodes.
+ */
+const getAncestry = function(node, root) {
+  const ancestry = [];
+  let cur = node;
+
+  while (cur !== root) {
+    ancestry.push(cur);
+    cur = cur.parentNode;
+  }
+
+  return ancestry;
+};
+
+
+/**
+ * @param {!Node} node
+ * @return {!Node} The root node of the DOM tree that contains node.
+ */
+const getRoot = function(node) {
+  let cur = node;
+  let prev = cur;
+
+  while (cur) {
+    prev = cur;
+    cur = cur.parentNode;
+  }
+
+  return prev;
+};
+
+
+/**
+ * @param {!Node} node The node to get the activeElement for.
+ * @return {?Element} The activeElement in the Document or ShadowRoot
+ *     corresponding to node, if present.
+ */
+const getActiveElement = function(node) {
+  const root = getRoot(node);
+  return isDocumentRoot(root) ? root.activeElement : null;
+};
+
+
+/**
+ * Gets the path of nodes that contain the focused node in the same document as
+ * a reference node, up until the root.
+ * @param {!Node} node The reference node to get the activeElement for.
+ * @param {?Node} root The root to get the focused path until.
+ * @return {!Array<Node>}
+ */
+const getFocusedPath = function(node, root) {
+  const activeElement = getActiveElement(node);
+
+  if (!activeElement || !node.contains(activeElement)) {
+    return [];
+  }
+
+  return getAncestry(activeElement, root);
+};
+
+
+/**
+ * Like insertBefore, but instead instead of moving the desired node, instead
+ * moves all the other nodes after.
+ * @param {?Node} parentNode
+ * @param {!Node} node
+ * @param {?Node} referenceNode
+ */
+const moveBefore = function(parentNode, node, referenceNode) {
+  const insertReferenceNode = node.nextSibling;
+  let cur = referenceNode;
+
+  while (cur !== node) {
+    const next = cur.nextSibling;
+    parentNode.insertBefore(cur, insertReferenceNode);
+    cur = next;
+  }
+};
+
+
+/** */
+export {
+  getFocusedPath,
+  moveBefore
+};
+

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -65,9 +65,15 @@ function NodeData(nodeName, key) {
 
   /**
    * Whether or not the keyMap is currently valid.
-   * {boolean}
+   * @type {boolean}
    */
   this.keyMapValid = true;
+
+  /**
+   * Whether or the associated node is, or contains, a focused Element.
+   * @type {boolean}
+   */
+  this.focused = false;
 
   /**
    * The node name for this node.

--- a/test/util/dom.js
+++ b/test/util/dom.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2016 The Incremental DOM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const BROWSER_SUPPORTS_SHADOW_DOM = 'ShadowRoot' in window;
+
+
+const attachShadow = function(el) {
+  return el.attachShadow ?
+      el.attachShadow({ mode: 'closed' }) :
+      el.createShadowRoot();
+};
+
+
+export {
+  BROWSER_SUPPORTS_SHADOW_DOM,
+  attachShadow
+};


### PR DESCRIPTION
- Keep track of whether each node is (or contains) a focused element
- If encountering a focused element, avoid moving it

Fixes #237