### PR TITLE
Micro opt: Use array iteration

### DIFF
--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -111,8 +111,8 @@ const elementOpen = function(tag, key, statics, var_args) {
    * Actually perform the attribute update.
    */
   if (attrsChanged) {
-    for (i = ATTRIBUTES_OFFSET; i < arguments.length; i += 2) {
-      newAttrs[arguments[i]] = arguments[i + 1];
+    for (i = 0; i < attrsArr.length; i += 2) {
+      newAttrs[attrsArr[i]] = attrsArr[i + 1];
     }
 
     for (const attr in newAttrs) {


### PR DESCRIPTION
Array iteration is ever so [slightly faster](http://justin.ridgewell.name/browser-benchmark/incremental-dom-forEach/index.html) than arguments iteration.

This is definitely micro opt territory. We should be able to save a few bytes by using the array reference, too.