### PR TITLE
Optimize attributes diff in elementOpen

### DIFF
--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -90,7 +90,7 @@ describe('attribute updates', () => {
       expect(el.getAttribute('data-expanded')).to.equal('bar');
     });
 
-    it('should update attribute in different position', () => {
+    it('should update different attribute in same position', () => {
       patch(container, () => render({
         'data-foo': 'foo'
       }));
@@ -101,6 +101,54 @@ describe('attribute updates', () => {
 
       expect(el.getAttribute('data-bar')).to.equal('foo');
       expect(el.getAttribute('data-foo')).to.equal(null);
+    });
+
+    it('should keep attribute in different position', () => {
+      patch(container, () => render({
+        'data-foo': 'foo',
+        'data-bar': 'bar'
+      }));
+      patch(container, () => render({
+        'data-bar': 'bar'
+      }));
+      const el = container.childNodes[0];
+      expect(el.getAttribute('data-foo')).to.equal(null);
+      expect(el.getAttribute('data-bar')).to.equal('bar');
+
+
+      patch(container, () => render({}));
+
+      patch(container, () => render({
+        'data-bar': 'bar'
+      }));
+      patch(container, () => render({
+        'data-foo': 'foo',
+        'data-bar': 'bar'
+      }));
+      expect(el.getAttribute('data-foo')).to.equal('foo');
+      expect(el.getAttribute('data-bar')).to.equal('bar');
+
+
+      patch(container, () => render({}));
+
+      patch(container, () => render({
+        'data-foo': 'foo',
+        'data-bar': 'bar',
+        'data-baz': 'baz'
+      }));
+      patch(container, () => render({
+        'data-bar': 'bar',
+        'data-baz': 'baz'
+      }));
+      expect(el.getAttribute('data-foo')).to.equal(null);
+      expect(el.getAttribute('data-bar')).to.equal('bar');
+      expect(el.getAttribute('data-baz')).to.equal('baz');
+      patch(container, () => render({
+        'data-bar': 'bar'
+      }));
+      expect(el.getAttribute('data-foo')).to.equal(null);
+      expect(el.getAttribute('data-bar')).to.equal('bar');
+      expect(el.getAttribute('data-baz')).to.equal(null);
     });
 
     it('should remove trailing attributes when missing', function() {


### PR DESCRIPTION
This optimizes the attributes diffing to only use `j` redundant accesses.
If a change is detected in the beginning (or near), then `j` is small
(possibly 0) and we get the largest gains. If the change is detected at
the end, then `j` is equal to the number of attribute name-values (so we
end up doing a second full iteration).

That's still better than the code before, which always guaranteed 2 full
iterations. Now we just do 1 full iteration, plus `j` (which may be
another full).

Supersedes #252 (notice we iterate `attrsArr` for those `j` redundant accesses).

Time for bed. :sleeping::zzz::zzz: