### PR TITLE
Optimize attributes diff  - moonshot

### DIFF
--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -87,30 +87,38 @@ const elementOpen = function(tag, key, statics, var_args) {
    */
   const attrsArr = data.attrsArr;
   const newAttrs = data.newAttrs;
-  let attrsChanged = false;
+  const isNew = !attrsArr.length;
   let i = ATTRIBUTES_OFFSET;
   let j = 0;
 
-  for (; i < arguments.length; i += 1, j += 1) {
-    if (attrsArr[j] !== arguments[i]) {
-      attrsChanged = true;
+  for (; i < arguments.length; i += 2, j += 2) {
+    const attr = arguments[i];
+    if (isNew) {
+      attrsArr[j] = attr;
+      newAttrs[attr] = undefined;
+    } else if (attrsArr[j] !== attr) {
       break;
+    }
+
+    const value = arguments[i + 1];
+    if (isNew || attrsArr[j + 1] !== value) {
+      attrsArr[j + 1] = value;
+      updateAttribute(node, attr, value);
     }
   }
 
-  for (; i < arguments.length; i += 1, j += 1) {
-    attrsArr[j] = arguments[i];
-  }
+  if (i < arguments.length || j < attrsArr.length) {
+    for (; i < arguments.length; i += 1, j += 1) {
+      attrsArr[j] = arguments[i];
+    }
 
-  if (j < attrsArr.length) {
-    attrsChanged = true;
-    attrsArr.length = j;
-  }
+    if (j < attrsArr.length) {
+      attrsArr.length = j;
+    }
 
-  /*
-   * Actually perform the attribute update.
-   */
-  if (attrsChanged) {
+    /*
+     * Actually perform the attribute update.
+     */
     for (i = 0; i < attrsArr.length; i += 2) {
       newAttrs[attrsArr[i]] = attrsArr[i + 1];
     }

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -90,7 +90,7 @@ describe('attribute updates', () => {
       expect(el.getAttribute('data-expanded')).to.equal('bar');
     });
 
-    it('should update attribute in different position', () => {
+    it('should update different attribute in same position', () => {
       patch(container, () => render({
         'data-foo': 'foo'
       }));
@@ -101,6 +101,54 @@ describe('attribute updates', () => {
 
       expect(el.getAttribute('data-bar')).to.equal('foo');
       expect(el.getAttribute('data-foo')).to.equal(null);
+    });
+
+    it('should keep attribute in different position', () => {
+      patch(container, () => render({
+        'data-foo': 'foo',
+        'data-bar': 'bar'
+      }));
+      patch(container, () => render({
+        'data-bar': 'bar'
+      }));
+      const el = container.childNodes[0];
+      expect(el.getAttribute('data-foo')).to.equal(null);
+      expect(el.getAttribute('data-bar')).to.equal('bar');
+
+
+      patch(container, () => render({}));
+
+      patch(container, () => render({
+        'data-bar': 'bar'
+      }));
+      patch(container, () => render({
+        'data-foo': 'foo',
+        'data-bar': 'bar'
+      }));
+      expect(el.getAttribute('data-foo')).to.equal('foo');
+      expect(el.getAttribute('data-bar')).to.equal('bar');
+
+
+      patch(container, () => render({}));
+
+      patch(container, () => render({
+        'data-foo': 'foo',
+        'data-bar': 'bar',
+        'data-baz': 'baz'
+      }));
+      patch(container, () => render({
+        'data-bar': 'bar',
+        'data-baz': 'baz'
+      }));
+      expect(el.getAttribute('data-foo')).to.equal(null);
+      expect(el.getAttribute('data-bar')).to.equal('bar');
+      expect(el.getAttribute('data-baz')).to.equal('baz');
+      patch(container, () => render({
+        'data-bar': 'bar'
+      }));
+      expect(el.getAttribute('data-foo')).to.equal(null);
+      expect(el.getAttribute('data-bar')).to.equal('bar');
+      expect(el.getAttribute('data-baz')).to.equal(null);
     });
 
     it('should remove trailing attributes when missing', function() {

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -103,52 +103,84 @@ describe('attribute updates', () => {
       expect(el.getAttribute('data-foo')).to.equal(null);
     });
 
-    it('should keep attribute in different position', () => {
-      patch(container, () => render({
-        'data-foo': 'foo',
-        'data-bar': 'bar'
-      }));
-      patch(container, () => render({
-        'data-bar': 'bar'
-      }));
-      const el = container.childNodes[0];
-      expect(el.getAttribute('data-foo')).to.equal(null);
-      expect(el.getAttribute('data-bar')).to.equal('bar');
+    describe('for attributes in different position', () => {
+      it('should keep attribute that is moved up', () => {
+        patch(container, () => render({
+          'data-foo': 'foo',
+          'data-bar': 'bar'
+        }));
+        patch(container, () => render({
+          'data-bar': 'bar'
+        }));
+        const el = container.childNodes[0];
+
+        expect(el.getAttribute('data-foo')).to.equal(null);
+        expect(el.getAttribute('data-bar')).to.equal('bar');
+      });
 
 
-      patch(container, () => render({}));
+      it('should keep attribute that is moved back', () => {
+        patch(container, () => render({
+          'data-bar': 'bar'
+        }));
+        patch(container, () => render({
+          'data-foo': 'foo',
+          'data-bar': 'bar'
+        }));
+        const el = container.childNodes[0];
 
-      patch(container, () => render({
-        'data-bar': 'bar'
-      }));
-      patch(container, () => render({
-        'data-foo': 'foo',
-        'data-bar': 'bar'
-      }));
-      expect(el.getAttribute('data-foo')).to.equal('foo');
-      expect(el.getAttribute('data-bar')).to.equal('bar');
+        expect(el.getAttribute('data-foo')).to.equal('foo');
+        expect(el.getAttribute('data-bar')).to.equal('bar');
+      });
 
+      it('should keep attribute that is moved up then kept', () => {
+        patch(container, () => render({
+          'data-foo': 'foo',
+          'data-bar': 'bar',
+          'data-baz': 'baz'
+        }));
+        patch(container, () => render({
+          'data-bar': 'bar',
+          'data-baz': 'baz'
+        }));
+        const el = container.childNodes[0];
 
-      patch(container, () => render({}));
+        expect(el.getAttribute('data-foo')).to.equal(null);
+        expect(el.getAttribute('data-bar')).to.equal('bar');
+        expect(el.getAttribute('data-baz')).to.equal('baz');
 
-      patch(container, () => render({
-        'data-foo': 'foo',
-        'data-bar': 'bar',
-        'data-baz': 'baz'
-      }));
-      patch(container, () => render({
-        'data-bar': 'bar',
-        'data-baz': 'baz'
-      }));
-      expect(el.getAttribute('data-foo')).to.equal(null);
-      expect(el.getAttribute('data-bar')).to.equal('bar');
-      expect(el.getAttribute('data-baz')).to.equal('baz');
-      patch(container, () => render({
-        'data-bar': 'bar'
-      }));
-      expect(el.getAttribute('data-foo')).to.equal(null);
-      expect(el.getAttribute('data-bar')).to.equal('bar');
-      expect(el.getAttribute('data-baz')).to.equal(null);
+        patch(container, () => render({
+          'data-bar': 'bar'
+        }));
+        expect(el.getAttribute('data-foo')).to.equal(null);
+        expect(el.getAttribute('data-bar')).to.equal('bar');
+        expect(el.getAttribute('data-baz')).to.equal(null);
+      });
+
+      it('should keep attribute that is backwards up then kept', () => {
+        patch(container, () => render({
+          'data-bar': 'bar',
+          'data-baz': 'baz'
+        }));
+        patch(container, () => render({
+          'data-foo': 'foo',
+          'data-bar': 'bar',
+          'data-baz': 'baz'
+        }));
+        const el = container.childNodes[0];
+
+        expect(el.getAttribute('data-foo')).to.equal('foo');
+        expect(el.getAttribute('data-bar')).to.equal('bar');
+        expect(el.getAttribute('data-baz')).to.equal('baz');
+
+        patch(container, () => render({
+          'data-foo': 'foo',
+          'data-bar': 'bar'
+        }));
+        expect(el.getAttribute('data-foo')).to.equal('foo');
+        expect(el.getAttribute('data-bar')).to.equal('bar');
+        expect(el.getAttribute('data-baz')).to.equal(null);
+      });
     });
 
     it('should remove trailing attributes when missing', function() {


### PR DESCRIPTION
Ok, https://github.com/google/incremental-dom/pull/253 got me thinking how we can really optimize our attributes diffing. And this is what I came up with.

I think we have 3 average cases, then 3 edge cases with out code.

- Average Case
  1. New element, need to set all the attributes
  2. Same attributes, values may have changed
  3. No changes
- Edge Case
  1. Attribute has been dropped
  2. Attributes have shifted around
  3. New attribute replacing old one

We should make the two average cases fast as hell. And maybe make the edge cases faster, but they aren't the priority.

Well, here are the differences (http://justin.ridgewell.name/browser-benchmark/incremental-dom-attrs-diffing/index.html):

- Average Case
  1. ~10% faster
  2. 200-400% faster
  3. same, can't win everything. ¯\\_(ツ)_/¯
- Edge Case
  1. It's really hard to test this.
  2. ~50% faster
  3. 200% faster

Looks gigantic (adds about 100 bytes to min), but the speed is impressive.

Oh, and this _almost_ gets attributes completely out of core. 🎉 