### PR TITLE
Allow imported attributes to be declared static

### DIFF
--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -66,12 +66,19 @@ const elementOpen = function(tag, key, statics, var_args) {
 
   const node = coreElementOpen(tag, key);
   const data = getData(node);
+  const attrsArr = data.attrsArr;
+  const newAttrs = data.newAttrs;
+  const isNew = !attrsArr.length;
 
   if (!data.staticsApplied) {
     if (statics) {
       for (let i = 0; i < statics.length; i += 2) {
         const name = /** @type {string} */(statics[i]);
         const value = statics[i + 1];
+        if (name in newAttrs) {
+          delete newAttrs[name];
+          attrsArr.splice(attrsArr.indexOf(name), 2);
+        }
         updateAttribute(node, name, value);
       }
     }
@@ -87,9 +94,6 @@ const elementOpen = function(tag, key, statics, var_args) {
    * individual argument. When attributes have changed, the overhead of this is
    * minimal.
    */
-  const attrsArr = data.attrsArr;
-  const newAttrs = data.newAttrs;
-  const isNew = !attrsArr.length;
   let i = ATTRIBUTES_OFFSET;
   let j = 0;
 

--- a/test/functional/attributes.js
+++ b/test/functional/attributes.js
@@ -383,6 +383,24 @@ describe('attribute updates', () => {
       expect(grandChild.getAttribute('data-foo')).to.equal('bar');
     });
 
+    it('should allow declaring an imported attribute as static', () => {
+      function render(first) {
+        if (first) {
+          elementVoid('div', null, ['tabindex', '0']);
+        } else {
+          elementVoid('div');
+        }
+      }
+
+      patch(container, render, true);
+      const child = container.childNodes[0];
+
+      expect(child.getAttribute('tabindex')).to.equal('0');
+
+      patch(container, render, false);
+      expect(child.getAttribute('tabindex')).to.equal('0');
+    });
+
   });
 });
 


### PR DESCRIPTION
A second bug (maybe) that I noticed from https://github.com/google/incremental-dom/pull/257. When a node is imported with an attribute, that attr was always a dynamic attr. This allows the first patch to promote that imported attr into a static one, saving time in later patches.
