### PR TITLE
Use consecutive pushes

### DIFF
--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -163,7 +163,8 @@ const attr = function(name, value) {
     assertInAttributes('attr');
   }
 
-  argsBuilder.push(name, value);
+  argsBuilder.push(name);
+  argsBuilder.push(value);
 };
 
 


### PR DESCRIPTION
Small space savings, and use two pushes which, as you mentioned, is surprisingly much faster.