### PR TITLE
Update Closure Compiler to v20160517 and fix existing warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-plugin-transform-inline-environment-variables": "^6.5.0",
     "chai": "^3.0.0",
     "del": "^2.0.2",
-    "google-closure-compiler": "^20160315.2.0",
+    "google-closure-compiler": "^20160517.1.0",
     "gulp": "^3.9.0",
     "gulp-eslint": "^2.0.0",
     "gulp-replace": "^0.5.4",

--- a/src/core.js
+++ b/src/core.js
@@ -187,12 +187,12 @@ const patchOuter = patchFactory(function(node, fn, data) {
  * Checks whether or not the current node matches the specified nodeName and
  * key.
  *
+ * @param {!Node} matchNode A node to match the data to.
  * @param {?string} nodeName The nodeName for this node.
  * @param {?string=} key An optional key that identifies a node.
- * @param {Element=} matchNode An optional node to match the data to.
  * @return {boolean} True if the node matches, false otherwise.
  */
-const matches = function(nodeName, key, matchNode) {
+const matches = function(matchNode, nodeName, key) {
   const data = getData(matchNode);
 
   // Key check is done using double equals as we want to treat a null key the
@@ -210,7 +210,7 @@ const matches = function(nodeName, key, matchNode) {
  * @param {?string=} key The key used to identify this element.
  */
 const alignWithDOM = function(nodeName, key) {
-  if (currentNode && matches(nodeName, key, currentNode)) {
+  if (currentNode && matches(currentNode, nodeName, key)) {
     return;
   }
 
@@ -223,7 +223,7 @@ const alignWithDOM = function(nodeName, key) {
   if (key) {
     const keyNode = keyMap[key];
     if (keyNode) {
-      if (matches(nodeName, key, keyNode)) {
+      if (matches(keyNode, nodeName, key)) {
         node = keyNode;
       } else if (keyNode === currentNode) {
         context.markDeleted(keyNode);


### PR DESCRIPTION
Update google-closure-compiler to 20160517.1.0

Fix Closure Compiler warnings:  
`matchNode` in `match()` cannot be optional / undefined, otherwise a
`TypeError` would be thrown in `getData()`.
