### PR TITLE
Insensitively Compare nodeName

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -198,7 +198,15 @@ const matches = function(nodeName, key) {
   // Key check is done using double equals as we want to treat a null key the
   // same as undefined. This should be okay as the only values allowed are
   // strings, null and undefined so the == semantics are not too weird.
-  return nodeName === data.nodeName && key == data.key;
+  if (key == data.key) {
+      if (nodeName === data.nodeName) {
+          return true;
+      } else if (nodeName.toLowerCase() === data.nodeName.toLowerCase()) {
+          data.nodeName = nodeName;
+          return true;
+      }
+  }
+  return false;
 };
 
 

--- a/test/functional/importing_element.js
+++ b/test/functional/importing_element.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2015 The Incremental DOM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  patch,
+  elementVoid,
+  elementOpen,
+  elementClose,
+  importNode
+} from '../../index';
+
+describe('importing element', () => {
+  let container;
+  let sandbox = sinon.sandbox.create();
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    document.body.removeChild(container);
+  });
+
+  describe('in HTML', () => {
+      it('handles normal nodeName capitalization', () => {
+          container.innerHTML = '<div></div>';
+          importNode(container);
+
+          const el = container.firstChild;
+          patch(container, () => elementVoid('div'));
+          expect(container.firstChild).to.equal(el);
+      });
+
+      it('handles odd nodeName capitalization', () => {
+          container.innerHTML = '<div></div>';
+          importNode(container);
+
+          const el = container.firstChild;
+          patch(container, () => elementVoid('DIV'));
+          expect(container.firstChild).to.equal(el);
+      });
+  });
+
+  describe('in HTML', () => {
+      it('handles normal nodeName capitalization', () => {
+          container.innerHTML = '<svg><forignObject></forignObject></svg>';
+          importNode(container);
+
+          const forign = container.firstChild.firstChild;
+          patch(container, () => {
+              elementOpen('svg')
+              elementVoid('forignObject')
+              elementClose('svg')
+          });
+          expect(container.firstChild.firstChild).to.equal(forign);
+      });
+
+      it('handles odd nodeName capitalization', () => {
+          container.innerHTML = '<svg><forignObject></forignObject></svg>';
+          importNode(container);
+
+          const forign = container.firstChild.firstChild;
+          patch(container, () => {
+              elementOpen('svg')
+              elementVoid('forignobject')
+              elementClose('svg')
+          });
+          expect(container.firstChild.firstChild).to.equal(forign);
+      });
+  });
+});
+


### PR DESCRIPTION
I left in a fast path when the case matches. Otherwise, we check to see
if the cases insensitively matches. If so, we update the nodeName so the
next patch will fast path.

Fixes https://github.com/google/incremental-dom/issues/266.