### PR TITLE
Provide a fallback for Object.create

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/google/incremental-dom.svg?branch=master)](https://travis-ci.org/google/incremental-dom) 
+[![Build Status](https://travis-ci.org/google/incremental-dom.svg?branch=master)](https://travis-ci.org/google/incremental-dom)
 
 # Incremental DOM
 
@@ -12,6 +12,10 @@ Incremental DOM is primarily intended as a compilation target for templating lan
 ## Supported Browsers
 
 Incremental DOM supports IE9 and above.
+
+### Caveats
+ - If running in a browser that does not support `Object.create` then there may
+   be inconsistent behavior if enumerable properties exist on `Object.prototype`.
 
 ## Usage
 

--- a/src/util.js
+++ b/src/util.js
@@ -27,7 +27,10 @@ const hasOwnProperty = Object.prototype.hasOwnProperty;
  */
 function Blank() {}
 
-Blank.prototype = Object.create(null);
+// Use Object.create, if available, so iteration over the map will not include
+// any properties added to Object.prototype. If it's not available then fallback
+// to using and object literal (which will include any Object.prototype props).
+Blank.prototype = Object.create ? Object.create(null) : {};
 
 
 /**


### PR DESCRIPTION
While IE8 is not supported, having this call in the global scope meant that an error would be thrown if this file was loaded in IE8.