### PR TITLE
Change 2-way diff logic to use a separate shared object.

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { getData } from './node_data';
 import { symbols } from './symbols';
 import {
   createMap,
@@ -136,17 +135,8 @@ const applyAttributeTyped = function(el, name, value) {
  * @param {*} value The attribute's value.
  */
 const updateAttribute = function(el, name, value) {
-  const data = getData(el);
-  const attrs = data.attrs;
-
-  if (attrs[name] === value) {
-    return;
-  }
-
   const mutator = attributes[name] || attributes[symbols.default];
   mutator(el, name, value);
-
-  attrs[name] = value;
 };
 
 

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -26,24 +26,12 @@ import { createMap } from './util';
  */
 function NodeData(nodeName, key, typeId) {
   /**
-   * The attributes and their values.
-   * @const {!Object<string, *>}
-   */
-  this.attrs = createMap();
-
-  /**
    * An array of attribute name/value pairs, used for quickly diffing the
    * incomming attributes to see if the DOM node's attributes need to be
    * updated.
    * @const {Array<*>}
    */
   this.attrsArr = [];
-
-  /**
-   * The incoming attributes for this Node, before they are updated.
-   * @const {!Object<string, *>}
-   */
-  this.newAttrs = createMap();
 
   /**
    * Whether or not the statics have been applied for the node yet.
@@ -143,8 +131,6 @@ const importNode = function(node) {
 
   if (isElement) {
     const attributes = node.attributes;
-    const attrs = data.attrs;
-    const newAttrs = data.newAttrs;
     const attrsArr = data.attrsArr;
 
     for (let i = 0; i < attributes.length; i += 1) {
@@ -152,8 +138,6 @@ const importNode = function(node) {
       const name = attr.name;
       const value = attr.value;
 
-      attrs[name] = value;
-      newAttrs[name] = undefined;
       attrsArr.push(name);
       attrsArr.push(value);
     }


### PR DESCRIPTION
This removes the need for two objects per DOM node (`attrs` and `newAttrs`) in addition to `attrsArr`.

There shouldn't be much of a performance difference either way since attributes should generally line up as before. There is a slight benefit to initial creation time due to the extra objects not being created.