### PR TITLE
Use nodeType instead of instanceof.

### DIFF
--- a/src/dom_util.js
+++ b/src/dom_util.js
@@ -20,10 +20,7 @@
  * @return {boolean} True if the node the root of a document, false otherwise.
  */
 const isDocumentRoot = function(node) {
-  // For ShadowRoots, check if they are a DocumentFragment instead of if they
-  // are a ShadowRoot so that this can work in 'use strict' if ShadowRoots are
-  // not supported.
-  return node instanceof Document || node instanceof DocumentFragment;
+  return node.nodeType === 11 || node.nodeType === 9;
 };
 
 

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -121,7 +121,7 @@ const importNode = function(node) {
     return;
   }
 
-  const isElement = node instanceof Element;
+  const isElement = node.nodeType === 1;
   const nodeName = isElement ? node.localName : node.nodeName;
   const key = isElement ? node.getAttribute('key') : null;
   const data = initData(node, nodeName, key);


### PR DESCRIPTION
These checks are not hit that often, but seems like `instanceof` is quite a bit [slower](https://jsperf.com/is-node-document/) than checking `nodeType`. Sacrifice to readability isn't too bad.