### PR TITLE
Import `typeId` from Nodes if specified when importing DOM.

### DIFF
--- a/src/node_data.js
+++ b/src/node_data.js
@@ -124,7 +124,8 @@ const importNode = function(node) {
   const isElement = node instanceof Element;
   const nodeName = isElement ? node.localName : node.nodeName;
   const key = isElement ? node.getAttribute('key') : null;
-  const data = initData(node, nodeName, key);
+  const typeId = node['typeId'];
+  const data = initData(node, nodeName, key, typeId);
 
   if (key) {
     getData(node.parentNode).keyMap[key] = node;

--- a/test/functional/type_id.js
+++ b/test/functional/type_id.js
@@ -71,5 +71,15 @@ describe('typeId', () => {
 
     expect(container.children).to.have.length(2);
   });
+
+  it('should re-use elements created externally', () => {
+    const div = document.createElement('div');
+    div.typeId = 'someTypeId';
+
+    container.appendChild(div);
+    patch(container, () => render('div', null, div.typeId));
+
+    expect(container.firstChild).to.equal(div);
+  });
 });
 


### PR DESCRIPTION
This can be used for frameworks to mark imported DOM with a `typeId` based on some combination of other attributes prior to the first patch. This slightly differs from `key` in that it is not intended to be supplied by the developer.