### PR TITLE
Pass typeId through elementOpen

### DIFF
--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -64,8 +64,10 @@ const prevAttrsMap = createMap();
  * @param {?Array<*>=} statics An array of attribute name/value pairs of the
  *     static attributes for the Element. These will only be set once when the
  *     Element is created.
- * @param {...*} var_args, Attribute name/value pairs of the dynamic attributes
+ * @param {...*} var_args Attribute name/value pairs of the dynamic attributes
  *     for the Element.
+ * @param {*=} typeId An type identifier that avoids reuse between elements that
+ *     would otherwise match.
  * @return {!Element} The corresponding Element.
  */
 const elementOpen = function(nameOrCtor, key, statics, var_args) {
@@ -74,7 +76,15 @@ const elementOpen = function(nameOrCtor, key, statics, var_args) {
     assertNotInSkip('elementOpen');
   }
 
-  const node = open(nameOrCtor, key);
+  let varArgsLength = arguments.length;
+  let typeId;
+
+  if (varArgsLength > ATTRIBUTES_OFFSET && varArgsLength % 2 === 0) {
+    varArgsLength--;
+    typeId = arguments[varArgsLength];
+  }
+
+  const node = open(nameOrCtor, key, typeId);
   const data = getData(node);
 
   if (!data.staticsApplied) {
@@ -102,7 +112,7 @@ const elementOpen = function(nameOrCtor, key, statics, var_args) {
   let i = ATTRIBUTES_OFFSET;
   let j = 0;
 
-  for (; i < arguments.length; i += 2, j += 2) {
+  for (; i < varArgsLength; i += 2, j += 2) {
     const name = arguments[i];
     if (isNew) {
       attrsArr[j] = name;
@@ -123,14 +133,14 @@ const elementOpen = function(nameOrCtor, key, statics, var_args) {
    * attrs through the elementOpenStart flow or if one element is reused in
    * the place of another.
    */
-  if (i < arguments.length || j < attrsArr.length) {
+  if (i < varArgsLength || j < attrsArr.length) {
     const attrsStart = j;
 
     for (; j < attrsArr.length; j += 2) {
       prevAttrsMap[attrsArr[j]] = attrsArr[j + 1];
     }
 
-    for (j = attrsStart; i < arguments.length; i += 2, j += 2) {
+    for (j = attrsStart; i < varArgsLength; i += 2, j += 2) {
       const name = arguments[i];
       const value = arguments[i + 1];
 

--- a/test/functional/type_id.js
+++ b/test/functional/type_id.js
@@ -17,7 +17,8 @@
 import {
   patch,
   open,
-  close
+  close,
+  elementVoid
 } from '../../index';
 
 describe('typeId', () => {
@@ -70,6 +71,22 @@ describe('typeId', () => {
     });
 
     expect(container.children).to.have.length(2);
+  });
+
+  it('should pass typeId through virtual elements', () => {
+    patch(container, () => render('div', null, 1));
+    const div = container.firstChild;
+
+    patch(container, () => {
+      elementVoid('div', null, null, 'attr', 'value', 1);
+    });
+    expect(container.firstChild).to.equal(div);
+    expect(div.getAttribute('attr')).to.equal('value');
+
+    patch(container, () => {
+      elementVoid('div', null, null, 'attr', 'value', 2);
+    });
+    expect(container.firstChild).to.not.equal(div);
   });
 });
 


### PR DESCRIPTION
I know it's in a very unfortunate position, but I'd love to be able to
pass the `typeId` through the same element functions that handle the
attribute patching.