### PR TITLE
Change array truncation to use `pop` instead of setting length.

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -50,9 +50,22 @@ const createMap = function() {
 };
 
 
+/**
+ * Truncates an array, removing items up until length.
+ * @param {!Array<*>} arr The array to truncate.
+ * @param {number} length The new length of the array.
+ */
+const truncateArray = function(arr, length) {
+  while (arr.length > length) {
+    arr.pop();
+  }
+};
+
+
 /** */
 export {
   createMap,
-  has
+  has,
+  truncateArray
 };
 

--- a/src/virtual_elements.js
+++ b/src/virtual_elements.js
@@ -29,7 +29,10 @@ import {
   assertCloseMatchesOpenTag,
   setInAttributes
 } from './assertions';
-import { createMap } from './util';
+import {
+  createMap,
+  truncateArray
+} from './util';
 
 
 /**
@@ -43,7 +46,7 @@ const ATTRIBUTES_OFFSET = 3;
 /**
  * Builds an array of arguments for use with elementOpenStart, attr and
  * elementOpenEnd.
- * @const {Array<*>}
+ * @const {!Array<*>}
  */
 const argsBuilder = [];
 
@@ -145,7 +148,7 @@ const elementOpen = function(nameOrCtor, key, statics, var_args) {
     }
 
     if (j < attrsArr.length) {
-      attrsArr.length = j;
+      truncateArray(attrsArr, j);
     }
 
     /*
@@ -216,7 +219,7 @@ const elementOpenEnd = function() {
   }
 
   const node = elementOpen.apply(null, argsBuilder);
-  argsBuilder.length = 0;
+  truncateArray(argsBuilder, 0);
   return node;
 };
 


### PR DESCRIPTION
This change was originally proposed in #151 for the attributes array trunctation. While that is still generally a rare case, the `argsBuilder` (for `elementOpenStart`) is used quite often in practice.  For the list test (converted to use `elementOpenStart`), this results in ~25% faster diffs. This is also needed for future changes that will shift the primary API to be more like `elementOpenStart`.