### PR TITLE
Optimize with a monotonic increasing typeId

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -36,6 +36,8 @@ import {
   moveBefore
 } from './dom_util.js';
 import { global } from './global.js';
+import { notNaN } from './util.js';
+
 
 /** @type {?Node} */
 let currentNode = null;
@@ -182,7 +184,7 @@ const patchOuter = patchFactory(function(node, fn, data) {
  * @param {!Node} matchNode A node to match the data to.
  * @param {NameOrCtorDef} nameOrCtor The name or constructor to check for.
  * @param {?string=} key An optional key that identifies a node.
- * @param {*=} typeId An type identifier that avoids reuse between elements that
+ * @param {number} typeId A type identifier that avoids reuse between elements that
  *     would otherwise match.
  * @return {boolean} True if the node matches, false otherwise.
  */
@@ -203,43 +205,101 @@ const matches = function(matchNode, nameOrCtor, key, typeId) {
  * corresponding DOM node to the correct location or creating it if necessary.
  * @param {NameOrCtorDef} nameOrCtor The name or constructor for the Node.
  * @param {?string=} key The key used to identify the Node..
- * @param {*=} typeId An type identifier that avoids reuse between elements that
+ * @param {number} typeId A type identifier that avoids reuse between elements that
  *     would otherwise match.
  */
 const alignWithDOM = function(nameOrCtor, key, typeId) {
-  if (currentNode && matches(currentNode, nameOrCtor, key, typeId)) {
-    return;
+  let next = currentNode;
+  // Clear out nodes with lower typeIds, which means that they should have come
+  // before the new node being aligned.
+  while (next && getData(next).typeId < typeId) {
+    next = next.nextSibling;
+  }
+  if (next !== currentNode) {
+    clearUnvisitedDOM(currentParent, currentNode, next);
+    currentNode = next;
   }
 
-  const parentData = getData(currentParent);
-  const keyMap = parentData.keyMap;
+  if (currentNode) {
+    alignNodeWith(nameOrCtor, key, typeId);
+  } else {
+    insertNode(nameOrCtor, key, typeId);
+  }
+}
+
+
+/**
+ * Creates the new node, and updates the parent's keyMap.
+ * @param {NameOrCtorDef} nameOrCtor
+ * @param {?string=} key
+ * @param {number} typeId
+ * @return {!Text|!Element}
+ */
+const createNode = function(nameOrCtor, key, typeId) {
+  if (nameOrCtor === '#text') {
+    return createText(doc);
+  }
+
+  const element = createElement(doc, currentParent, nameOrCtor, key, typeId);
+
+  if (key) {
+    const parentData = getData(currentParent);
+    parentData.keyMap[key] = element;
+  }
+
+  return element;
+};
+
+
+/**
+ * Inserts the new node without expensive alignment checking.
+ * This is only called when there is not a current node to align against.
+ * @param {NameOrCtorDef} nameOrCtor
+ * @param {?string=} key
+ * @param {number} typeId
+ */
+const insertNode = function(nameOrCtor, key, typeId) {
+  const node = createNode(nameOrCtor, key, typeId);
+  currentParent.appendChild(node);
+  currentNode = node;
+};
+
+
+/**
+ * Aligns the new node with the current node, reusing a previous node if
+ * possible or inserting if not.
+ * @param {NameOrCtorDef} nameOrCtor
+ * @param {?string=} key
+ * @param {number} typeId
+ */
+const alignNodeWith = function(nameOrCtor, key, typeId) {
   let node;
 
   // Check to see if the node has moved within the parent.
   if (key) {
+    const keyMap = getData(currentParent).keyMap;
     const keyNode = keyMap[key];
-    if (keyNode) {
-      if (matches(keyNode, nameOrCtor, key, typeId)) {
-        node = keyNode;
-      } else {
-        // When the keyNode gets removed later, make sure we do not remove the
-        // new node from the map.
-        getData(keyNode).key = null;
+    if (keyNode && matches(keyNode, nameOrCtor, key, typeId)) {
+      node = keyNode;
+    }
+  }
+
+  // Scan ahead to see if there is a matching node.
+  if (!node) {
+    let maybe = currentNode;
+    while (maybe && getData(maybe).typeId === typeId) {
+      if (matches(maybe, nameOrCtor, key, typeId)) {
+        node = maybe;
+        break;
       }
+
+      maybe = maybe.nextSibling;
     }
   }
 
   // Create the node if it doesn't exist.
   if (!node) {
-    if (nameOrCtor === '#text') {
-      node = createText(doc);
-    } else {
-      node = createElement(doc, currentParent, nameOrCtor, key, typeId);
-    }
-
-    if (key) {
-      keyMap[key] = node;
-    }
+    node = createNode(nameOrCtor, key, typeId);
   }
 
   // Re-order the node into the right position, preserving focus if either
@@ -270,10 +330,10 @@ const clearUnvisitedDOM = function(parentNode, startNode, endNode) {
   while (child !== endNode) {
     const next = child.nextSibling;
     const key = getData(child).key;
-    parentNode.removeChild(child);
-    if (key) {
+    if (key && keyMap[key] === child) {
       delete keyMap[key];
     }
+    parentNode.removeChild(child);
     child = next;
   }
 };
@@ -327,13 +387,13 @@ const exitNode = function() {
  * @param {?string=} key The key used to identify this element. This can be an
  *     empty string, but performance may be better if a unique value is used
  *     when iterating over an array of items.
- * @param {*=} typeId An type identifier that avoids reuse between elements that
+ * @param {number=} typeId A type identifier that avoids reuse between elements that
  *     would otherwise match.
  * @return {!Element} The corresponding Element.
  */
 const open = function(nameOrCtor, key, typeId) {
   nextNode();
-  alignWithDOM(nameOrCtor, key, typeId);
+  alignWithDOM(nameOrCtor, key, notNaN(typeId));
   enterNode();
   return /** @type {!Element} */(currentParent);
 };
@@ -363,7 +423,7 @@ const close = function() {
  */
 const text = function() {
   nextNode();
-  alignWithDOM('#text', null);
+  alignWithDOM('#text', null, -Infinity);
   return /** @type {!Text} */(currentNode);
 };
 

--- a/src/node_data.js
+++ b/src/node_data.js
@@ -15,14 +15,17 @@
  */
 
 import { NameOrCtorDef } from './types.js';
-import { createMap } from './util.js';
+import {
+  createMap,
+  notNaN
+} from './util.js';
 
 
 /**
  * Keeps track of information needed to perform diffs for a given DOM node.
  * @param {NameOrCtorDef} nameOrCtor
  * @param {?string=} key
- * @param {*=} typeId
+ * @param {number} typeId
  * @constructor
  */
 function NodeData(nameOrCtor, key, typeId) {
@@ -83,7 +86,7 @@ function NodeData(nameOrCtor, key, typeId) {
  * @param {Node} node The node to initialize data for.
  * @param {NameOrCtorDef} nameOrCtor The nodeName or constructor for the Node.
  * @param {?string=} key The key that identifies the node.
- * @param {*=} typeId The type identifier for the Node.
+ * @param {number} typeId The type identifier for the Node.
  * @return {!NodeData} The newly initialized data object
  */
 const initData = function(node, nameOrCtor, key, typeId) {
@@ -118,7 +121,7 @@ const importNode = function(node) {
   const isElement = node.nodeType === 1;
   const nodeName = isElement ? node.localName : node.nodeName;
   const key = isElement ? node.getAttribute('key') : null;
-  const typeId = node['typeId'];
+  const typeId = notNaN(node['typeId']);
   const data = initData(node, nodeName, key, typeId);
 
   if (key) {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -46,7 +46,7 @@ const getNamespaceForTag = function(tag, parent) {
  * @param {?Node} parent
  * @param {NameOrCtorDef} nameOrCtor The tag or constructor for the Element.
  * @param {?string=} key A key to identify the Element.
- * @param {*=} typeId The type identifier for the Element.
+ * @param {number} typeId The type identifier for the Element.
  * @return {!Element}
  */
 const createElement = function(doc, parent, nameOrCtor, key, typeId) {
@@ -77,7 +77,7 @@ const createElement = function(doc, parent, nameOrCtor, key, typeId) {
  */
 const createText = function(doc) {
   const node = doc.createTextNode('');
-  initData(node, '#text', null);
+  initData(node, '#text', null, -Infinity);
   return node;
 };
 

--- a/src/util.js
+++ b/src/util.js
@@ -62,10 +62,27 @@ const truncateArray = function(arr, length) {
 };
 
 
+/**
+ * Coerces input into a number. If the number parses to NaN, returns -Infinity.
+ * @param {*} input
+ * @return {number}
+ */
+const notNaN = function(input) {
+  if (input == null) {
+    return -Infinity;
+  }
+
+  const number = parseInt(input, 10);
+  // Check for NaN
+  return number === number ? number : -Infinity;
+}
+
+
 /** */
 export {
   createMap,
   has,
-  truncateArray
+  truncateArray,
+  notNaN
 };
 


### PR DESCRIPTION
This has the interesting optimizations from #307, including:

1. Will remove elements with lower `typeId`s when considering the next node to align with.
   - Say we have elements `1`, `2`, `3`, and we pass in `2`. We know we can pop off `1` without further consideration (`typeId` is lower).
2. Will scan ahead elements when considering if there is a matching node, similar to `key`
   - Say we have elements `div-1`, `span-1`, `div-3`, and we pass in `span-1`. We can't pop `div-1` off just yet, because `typeId` is not lower. But we can scan ahead for similar `typeId`s (until with hit the `3`) to see if a matching element is ahead.
3. Will insert a lower `typeId` immediately, expecting higher ones to come.
   - Say we have just `2`, and we pass in `1`, `2`. Because `2` is higher than our `1`, we know we can insert immediately. Now when the `2` comes in second, we get a match.

Closes https://github.com/google/incremental-dom/issues/307.