### PR TITLE
Some types cleanup.

### DIFF
--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import {AttrMutatorConfig} from './types';
 import {symbols} from './symbols';
 import {createMap, has} from './util';
 
@@ -131,10 +132,7 @@ function applyAttributeTyped(el: HTMLElement, name: string, value: {}) {
  * will just assume attributes is "any" otherwise and throws away
  * the type annotation set by tsickle.
  */
-// tslint:disable:no-any
-const attributes: {[x: string]: (a: HTMLElement, b: string, c: any) => void} =
-    (createMap() as {[x: string]: (a: HTMLElement, b: string, c: any) => void});
-// tslint:enable:no-any
+const attributes: AttrMutatorConfig = (createMap() as AttrMutatorConfig);
 
 // Special generic mutator that's called for any attribute that does not
 // have a specific mutator.

--- a/src/core.ts
+++ b/src/core.ts
@@ -217,9 +217,8 @@ function alignWithDOM(
   if ((currentNode && matches(currentNode, nameOrCtor, key, typeId))) {
     return;
   }
-  assert(currentParent);
-  const parent = currentParent!;
 
+  const parent = currentParent!;
   const parentData = getData(parent);
   const keyMap = parentData.keyMap;
   let node;
@@ -240,13 +239,11 @@ function alignWithDOM(
 
   // Create the node if it doesn't exist.
   if (!node) {
-    assert(doc);
     if (nameOrCtor === '#text') {
       node = createText(doc!);
     } else {
       node = createElement(doc!, parent, nameOrCtor, key, typeId);
     }
-    assert(context);
     context!.markCreated(node);
 
     if (key) {
@@ -261,8 +258,7 @@ function alignWithDOM(
     // Move everything else before the node.
     moveBefore(parent, node, currentNode);
   } else {
-    assert(currentParent);
-    currentParent!.insertBefore(node, currentNode);
+    parent.insertBefore(node, currentNode);
   }
 
   currentNode = node;
@@ -277,15 +273,12 @@ function alignWithDOM(
  */
 function clearUnvisitedDOM(
     maybeParentNode: Node|null, startNode: Node|null, endNode: Node|null) {
-  assert(maybeParentNode);
   const parentNode = maybeParentNode!;
   const data = getData(parentNode);
   const keyMap = data.keyMap;
   let child = startNode;
 
-  assert(context);
   while (child !== endNode) {
-    assert(child);
     const next = child!.nextSibling;
     const key = getData(child!).key;
     parentNode.removeChild(child!);
@@ -314,7 +307,6 @@ function getNextNode(): Node|null {
   if (currentNode) {
     return currentNode.nextSibling;
   } else {
-    assert(currentParent);
     return currentParent!.firstChild;
   }
 }
@@ -335,7 +327,6 @@ function exitNode() {
   clearUnvisitedDOM(currentParent, getNextNode(), null);
 
   currentNode = currentParent;
-  assert(currentParent);
   currentParent = currentParent!.parentNode;
 }
 

--- a/src/dom_util.ts
+++ b/src/dom_util.ts
@@ -36,8 +36,7 @@ function getAncestry(node: Node, root: Node|null) {
   let cur: Node|null = node;
 
   while (cur !== root) {
-    assert(cur);
-    const n:Node = cur!;
+    const n: Node = cur!;
     ancestry.push(n);
     cur = n.parentNode;
   }

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -54,8 +54,7 @@ function createElement(
   let el;
 
   if (nameOrCtor instanceof Function) {
-    // tslint:disable-next-line:no-any
-    el = new (nameOrCtor as any)();
+    el = new nameOrCtor();
   } else {
     const namespace = getNamespaceForTag(nameOrCtor, parent);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,5 +15,11 @@
  * limitations under the License.
  */
 
+// tslint:disable-next-line:no-any
+export type AttrMutator = (a: HTMLElement, b: string, c: any) => void;
 
-export type NameOrCtorDef = string|Function;
+export type AttrMutatorConfig = {[x: string]: AttrMutator};
+
+export type ElementConstructor = new () => Element;
+
+export type NameOrCtorDef = string|ElementConstructor;


### PR DESCRIPTION
- Create type aliases to make things more readable.
- Remove some assert calls that are noisy, they will fail nearby anyway.
- Improve typing of `NameCtorOrDef` when passing a constructor function.