### PR TITLE
Remove assertion for keyNotSet

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -34,15 +34,6 @@ let inAttributes = false;
  */
 let inSkip = false;
 
-/**
- * Makes sure that a key is not set in an argsbuilder.
- */
-function assertKeyNotSet(argsBuilder: Array<{}|null|undefined>) {
-  if (argsBuilder[1]) {
-    throw new Error(`Cannot redefine key in ${argsBuilder[0]}`);
-  }
-}
-
 
 /**
  * Makes sure that there is a current patch context.
@@ -228,7 +219,6 @@ function assert<T extends {}>(val: T|null|undefined): T {
 
 export {
   assert,
-  assertKeyNotSet,
   assertInPatch,
   assertNoUnclosedTags,
   assertNotInAttributes,

--- a/src/virtual_elements.ts
+++ b/src/virtual_elements.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import {assert, assertCloseMatchesOpenTag, assertKeyNotSet, assertInAttributes, assertNotInAttributes, assertNotInSkip, setInAttributes} from './assertions';
+import {assert, assertCloseMatchesOpenTag, assertInAttributes, assertNotInAttributes, assertNotInSkip, setInAttributes} from './assertions';
 import {updateAttribute} from './attributes';
 import {getArgsBuilder, close, open, text as coreText} from './core';
 import {DEBUG} from './global';
@@ -190,7 +190,6 @@ function key(key:string) {
   if (DEBUG) {
     assertInAttributes('key');
     assert(argsBuilder);
-    assertKeyNotSet(argsBuilder!);
   }
   argsBuilder[1] = key;
 }


### PR DESCRIPTION
Remove unnecessary assertion for incrementaldom.key.

This will allow users to do the below.

elementOpen('div', 0);
     key('foo');
elementClose('div');

Where 0 is generated by the template and 'foo' is user created (from data).