### PR TITLE
Handle case where a node rendered during serverside rendering is focused

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -23,7 +23,7 @@ import {getFocusedPath, moveBefore} from './dom_util';
 import {DEBUG} from './global';
 import {getData} from './node_data';
 import {createElement, createText} from './nodes';
-import {Key, NameOrCtorDef} from './types';
+import {DEFERRED_KEY, Key, NameOrCtorDef} from './types';
 
 let context: Context|null = null;
 
@@ -62,7 +62,7 @@ function getArgsBuilder(): Array<{}|null|undefined>{
  */
 function markFocused(focusPath: Node[], focused: boolean) {
   for (let i = 0; i < focusPath.length; i += 1) {
-    getData(focusPath[i]).focused = focused;
+    getData(focusPath[i], DEFERRED_KEY).focused = focused;
   }
 }
 

--- a/src/node_data.ts
+++ b/src/node_data.ts
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-import {Key, NameOrCtorDef} from './types';
 import {isElement, isText} from './dom_util';
+import {DEFERRED_KEY, Key, NameOrCtorDef} from './types';
 
 
 /**
@@ -86,17 +86,24 @@ function getData(node: Node, key?: Key) {
   return importSingleNode(node, key);
 }
 
+function getKey(node: Node, key: Key) {
+  return isElement(node) ? (node.getAttribute('key') || key) : null;
+}
 
 /**
  * Imports single node and its subtree, initializing caches.
  */
 function importSingleNode(node: Node, fallbackKey?: Key) {
   if (node['__incrementalDOMData']) {
-    return node['__incrementalDOMData']!;
+    const data = node['__incrementalDOMData']!;
+    if (data.key === DEFERRED_KEY) {
+      data.key = getKey(node, fallbackKey);
+    }
+    return data;
   }
 
   const nodeName = isElement(node) ? node.localName : node.nodeName;
-  const key = isElement(node) ? (node.getAttribute('key') || fallbackKey) : null;
+  const key = getKey(node, fallbackKey);
   const text = isText(node) ? node.data : undefined;
   const data = initData(node, nodeName!, key, text);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+
+export const DEFERRED_KEY = class {};
+
 export interface ElementConstructor {new(): Element};
 
 // tslint:disable-next-line:no-any
@@ -24,6 +27,6 @@ export type AttrMutatorConfig = {[x: string]: AttrMutator};
 
 export type NameOrCtorDef = string|ElementConstructor;
 
-export type Key = string|number|null|undefined;
+export type Key = typeof DEFERRED_KEY|string|number|null|undefined;
 
 export type Statics = Array<{}>|null|undefined;

--- a/test/functional/keyed_items.ts
+++ b/test/functional/keyed_items.ts
@@ -231,6 +231,24 @@ describe('rendering with keys', () => {
     expect(observer.takeRecords()).to.be.empty;
   });
 
+  it('should preserve focus for nodes already in the DOM', () => {
+    function render() {
+      elementOpen('button', 0);
+        text('Foo');
+      elementClose('button');
+      elementVoid('div', 1);
+    }
+
+    patch(container, render);
+    // Simulate serverside rendering by clearing the cache.
+    clearCache(container);
+    const button = container.firstChild as HTMLButtonElement;
+    button.focus();
+    patch(container, render);
+
+    expect(document.activeElement).to.equal(button);
+  });
+
   describe('an item with focus', () => {
     function render(items: Key[]) {
       for (let i = 0; i < items.length; i++) {


### PR DESCRIPTION
User story:

Server-side render a template.
Immediately focus on an element.
Patch an element that had focus.

Right now a code path gets triggered where an element gets an undefined key. The patch then goes in with a defined key and deletes the element. This code defers the serverside rendered state until a proper key can be attached.