### PR TITLE
Do not track focus state on NodeData.

### DIFF
--- a/src/node_data.ts
+++ b/src/node_data.ts
@@ -51,11 +51,6 @@ export class NodeData {
    */
   readonly nameOrCtor: NameOrCtorDef;
 
-  /**
-   * Whether or the associated node is, or contains, a focused Element.
-   */
-  focused = false;
-
   constructor(nameOrCtor: NameOrCtorDef, key: Key, text: string|undefined) {
     this.nameOrCtor = nameOrCtor;
     this.key = key;

--- a/test/functional/keyed_items.ts
+++ b/test/functional/keyed_items.ts
@@ -241,6 +241,19 @@ describe('rendering with keys', () => {
       }
     }
 
+    it('should retain focus when importing DOM with inferred keys', () => {
+      const items = [{key: 'one'}, {key: 'two'}];
+
+      patch(container, () => render(items));
+      const focusNode = assertHTMLElement(container.querySelector('#two'));
+      focusNode.focus();
+      // Simulate serverside rendering by clearing the cache.
+      clearCache(container);
+      patch(container, () => render(items));
+
+      expect(document.activeElement).to.equal(focusNode);
+    });
+
     it('should retain focus when prepending a new item', () => {
       const items = [{key: 'one'}];
 


### PR DESCRIPTION
Remove the import of NodeData at the start of the patch for the focus
path, making inferred keys work correctly. The cost of checking the
focus path array is very small compared to either creating or moving a
Node.

Two side benefits are 1: we use less memory per Node and 2: we save
a few bytes on the gzipped payload.