### PR TITLE
Persist statics after serverside rendering

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -23,7 +23,7 @@ import {getFocusedPath, moveBefore} from './dom_util';
 import {DEBUG} from './global';
 import {getData} from './node_data';
 import {createElement, createText} from './nodes';
-import {Key, NameOrCtorDef} from './types';
+import {Key, NameOrCtorDef, Statics} from './types';
 
 let context: Context|null = null;
 
@@ -172,11 +172,12 @@ const patchOuter = patchFactory((node, fn, data) => {
  * @param matchNode A node to match the data to.
  * @param nameOrCtor The name or constructor to check for.
  * @param key The key used to identify the Node.
+ * @param statics Static properties for the node
  * @return True if the node matches, false otherwise.
  */
 function matches(
-    matchNode: Node, nameOrCtor: NameOrCtorDef, key: Key) {
-  const data = getData(matchNode, key);
+    matchNode: Node, nameOrCtor: NameOrCtorDef, key: Key, statics: Statics) {
+  const data = getData(matchNode, key, statics);
 
   // Key check is done using double equals as we want to treat a null key the
   // same as undefined. This should be okay as the only values allowed are
@@ -194,18 +195,19 @@ function matches(
  * @param key The key used to identify the Node.
  */
 function getMatchingNode(
-    matchNode: Node|null, nameOrCtor: NameOrCtorDef, key: Key): Node|null {
+    matchNode: Node|null, nameOrCtor: NameOrCtorDef, key: Key,
+    statics: Statics): Node|null {
   if (!matchNode) {
     return null;
   }
 
-  if (matches(matchNode, nameOrCtor, key)) {
+  if (matches(matchNode, nameOrCtor, key, statics)) {
     return matchNode;
   }
 
   if (key) {
     while ((matchNode = matchNode.nextSibling)) {
-      if (matches(matchNode, nameOrCtor, key)) {
+      if (matches(matchNode, nameOrCtor, key, statics)) {
         return matchNode;
       }
     }
@@ -242,8 +244,8 @@ function createNode(nameOrCtor: NameOrCtorDef, key:Key): Node {
  * @param nameOrCtor The name or constructor for the Node.
  * @param key The key used to identify the Node.
  */
-function alignWithDOM(nameOrCtor: NameOrCtorDef, key: Key) {
-  const existingNode = getMatchingNode(currentNode, nameOrCtor, key);
+function alignWithDOM(nameOrCtor: NameOrCtorDef, key: Key, statics: Statics) {
+  const existingNode = getMatchingNode(currentNode, nameOrCtor, key, statics);
   const node = existingNode || createNode(nameOrCtor, key);
 
   // If we are at the matching node, then we are done.
@@ -335,9 +337,10 @@ function exitNode() {
  *     when iterating over an array of items.
  * @return The corresponding Element.
  */
-function open(nameOrCtor: NameOrCtorDef, key?: Key): HTMLElement {
+function open(
+    nameOrCtor: NameOrCtorDef, key?: Key, statics?: Statics): HTMLElement {
   nextNode();
-  alignWithDOM(nameOrCtor, key);
+  alignWithDOM(nameOrCtor, key, statics);
   enterNode();
   return (currentParent as HTMLElement);
 }
@@ -363,7 +366,7 @@ function close() {
  */
 function text(): Text {
   nextNode();
-  alignWithDOM('#text', null);
+  alignWithDOM('#text', null, []);
   return (currentNode) as Text;
 }
 

--- a/src/node_data.ts
+++ b/src/node_data.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import {Key, NameOrCtorDef} from './types';
+import {Key, NameOrCtorDef, Statics} from './types';
 import {isElement, isText} from './dom_util';
 
 
@@ -77,15 +77,15 @@ function initData(
 /**
  * Retrieves the NodeData object for a Node, creating it if necessary.
  */
-function getData(node: Node, key?: Key) {
-  return importSingleNode(node, key);
+function getData(node: Node, key?: Key, statics?: Statics) {
+  return importSingleNode(node, key, statics);
 }
 
 
 /**
- * Imports single node and its subtree, initializing caches.
+ * Imports single node, initializing cache.
  */
-function importSingleNode(node: Node, fallbackKey?: Key) {
+function importSingleNode(node: Node, fallbackKey?: Key, statics?: Statics) {
   if (node['__incrementalDOMData']) {
     return node['__incrementalDOMData']!;
   }
@@ -94,6 +94,12 @@ function importSingleNode(node: Node, fallbackKey?: Key) {
   const key = isElement(node) ? (node.getAttribute('key') || fallbackKey) : null;
   const text = isText(node) ? node.data : undefined;
   const data = initData(node, nodeName!, key, text);
+  const staticsKeys:string[] = [];
+  if (statics) {
+    for (let i = 0; i < statics.length; i+=2) {
+      staticsKeys.push(statics[i] as string);
+    }
+  }
 
   if (isElement(node)) {
     const attributes = node.attributes;
@@ -104,8 +110,10 @@ function importSingleNode(node: Node, fallbackKey?: Key) {
       const name = attr.name;
       const value = attr.value;
 
-      attrsArr.push(name);
-      attrsArr.push(value);
+      if (staticsKeys.indexOf(name) < 0) {
+        attrsArr.push(name);
+        attrsArr.push(value);
+      }
     }
   }
 

--- a/src/virtual_elements.ts
+++ b/src/virtual_elements.ts
@@ -63,7 +63,7 @@ function elementOpen(
     assertNotInSkip('elementOpen');
   }
 
-  const node = open(nameOrCtor, key);
+  const node = open(nameOrCtor, key, statics);
   const data = getData(node);
 
   if (!data.staticsApplied) {

--- a/test/functional/attributes.ts
+++ b/test/functional/attributes.ts
@@ -19,7 +19,7 @@
 // taze: mocha from //third_party/javascript/typings/mocha
 // taze: chai from //third_party/javascript/typings/chai
 
-import {attr, elementClose, elementOpen, elementOpenEnd, elementOpenStart, elementVoid, importNode, patch} from '../../index';
+import {attr, clearCache, elementClose, elementOpen, elementOpenEnd, elementOpenStart, elementVoid, importNode, patch} from '../../index';
 const {expect} = chai;
 
 describe('attribute updates', () => {
@@ -342,6 +342,29 @@ describe('attribute updates', () => {
 
       expect(child.getAttribute('data-foo')).to.equal('bar');
 
+      patch(container, render, 'baz');
+      expect(child.getAttribute('data-foo')).to.equal('bar');
+    });
+
+    it('should persist statics for serverside rendering', () => {
+      // tslint:disable-next-line:no-any
+      function render(value: any) {
+        elementVoid('div', null, ['data-foo', value]);
+      }
+
+      patch(container, render, 'bar');
+      const child = container.childNodes[0]! as HTMLElement;
+
+      expect(child.getAttribute('data-foo')).to.equal('bar');
+      // Simulate serverside rendering
+      clearCache(container);
+
+      // First patch should have the same parameters as the
+      // serverside render.
+      patch(container, render, 'bar');
+      expect(child.getAttribute('data-foo')).to.equal('bar');
+
+      // Now statics should persist.
       patch(container, render, 'baz');
       expect(child.getAttribute('data-foo')).to.equal('bar');
     });


### PR DESCRIPTION
For templates rendered with serverside rendering, statics currently today are cleared. This is because they are populated from getData and then placed into the prevAttrsArray gets removed if it hasn't been visited.