### PR TITLE
When importing DOM, apply statics with different values.

### DIFF
--- a/src/virtual_elements.ts
+++ b/src/virtual_elements.ts
@@ -57,25 +57,31 @@ function applyStatics(node: HTMLElement, statics: Statics, attrsArr: any[]) {
   for (let i = 0; i < statics.length; i += 2) {
     prevAttrsMap[statics[i] as string] = i + 1;
   }
-  
+
   let j = 0;
   for (let i = 0; i < attrsArr.length; i += 2) {
     const name = attrsArr[i];
+    const value = attrsArr[i + 1];
+    const staticsIndex = prevAttrsMap[name];
 
-    // For any attrs that are static, make sure we do not set them again.
-    if (prevAttrsMap[name]) {
-      delete prevAttrsMap[name];
+    if (staticsIndex) {
+      // For any attrs that are static and have the same value, make sure we do
+      // not set them again.
+      if (statics[staticsIndex] === value) {
+        delete prevAttrsMap[name];
+      }
+
       continue;
     }
 
     // For any attrs that are dynamic, move them up to the right place.
     attrsArr[j] = name;
-    attrsArr[j + 1] = attrsArr[i + 1];
+    attrsArr[j + 1] = value;
     j += 2;
   }
   // Anything after `j` was either moved up already or static.
   truncateArray(attrsArr, j);
-  
+
   for (const name in prevAttrsMap) {
     updateAttribute(node, name, statics[prevAttrsMap[name]]);
     delete prevAttrsMap[name];

--- a/test/functional/attributes.ts
+++ b/test/functional/attributes.ts
@@ -362,7 +362,7 @@ describe('attribute updates', () => {
       expect(div.onclick).to.equal(onclick);
     });
 
-    it('should not re-apply existing statics', () => {
+    it('should not re-apply existing statics with the same vaue', () => {
       div.setAttribute('data-foo', 'bar');
       const mo = createMutationObserver(div);
 
@@ -371,6 +371,15 @@ describe('attribute updates', () => {
       });
 
       expect(mo.takeRecords()).to.be.empty
+    });
+
+    it('should apply changed statics', () => {
+      patch(container, () => {
+        elementVoid('div', null, ['tabindex', '42']);
+      });
+      const child = container.firstElementChild!;
+
+      expect(child.getAttribute('tabindex')).to.equal('42');
     });
 
     it('should not re-apply existing statics regardless of order', () => {


### PR DESCRIPTION
When importing server rendered DOM, statics may not match when Elements
are reused. Ideally, a no-op patch should be applied (which would avoid
this problem), but it is not always feasible. Ideally, key should also
be used when statics are used, but some server-side rendered DOM might
omit keys (e.g. to reduce the payload transmitted).

For example, if you have something like:

```html
{if $condition}
  <div class="a"></div>
{else}
  <div class="b"></div>
{/if}
```

If the condition changes on the first patch (did not do a no-op patch), and you do not include keys in the server rendered DOM, then we want to make sure we end up with the right `class` value.