### PR TITLE
Add support for MathML

### DIFF
--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -28,6 +28,10 @@ function getNamespaceForTag(tag: string, parent: Node|null) {
   if (tag === 'svg') {
     return 'http://www.w3.org/2000/svg';
   }
+  
+  if (tag === 'math') {
+    return 'http://www.w3.org/1998/Math/MathML';
+  }
 
   if (parent == null) {
     return null;

--- a/test/functional/element_creation.ts
+++ b/test/functional/element_creation.ts
@@ -202,4 +202,46 @@ describe('element creation', () => {
          expect(el.namespaceURI).to.equal('http://www.w3.org/2000/svg');
        });
   });
+
+  describe('for math elements', () => {
+    beforeEach(() => {
+      patch(container, () => {
+        elementOpen('math');
+          elementOpen('semantics');
+            elementOpen('mrow');
+              elementVoid('mo');
+            elementClose('mrow');
+          elementClose('semantics');
+        elementClose('math');
+        elementVoid('p');
+      });
+    });
+
+    it('should create equations in the MathML namespace', () => {
+      const el = assertElement(container.querySelector('math'));
+      expect(el.namespaceURI).to.equal('http://www.w3.org/1998/Math/MathML');
+    });
+
+    it('should create descendants of math in the MathML namespace', () => {
+      const el = assertElement(container.querySelector('mo'));
+      expect(el.namespaceURI).to.equal('http://www.w3.org/1998/Math/MathML');
+    });
+
+    it('should reset to the previous namespace after exiting math',
+       () => {
+         const el = assertElement(container.querySelector('p'));
+         expect(el.namespaceURI).to.equal('http://www.w3.org/1999/xhtml');
+       });
+
+    it('should create children in the MathML namespace when patching an equation',
+       () => {
+         const mrow = assertElement(container.querySelector('mrow'));
+         patch(mrow, () => {
+           elementVoid('mi');
+         });
+
+         const el = assertElement(mrow.querySelector('mi'));
+         expect(el.namespaceURI).to.equal('http://www.w3.org/1998/Math/MathML');
+       });
+  });
 });


### PR DESCRIPTION
Until now, MathML equations weren't supported, as `<math>` and its child tags were placed in the XHTML namespace. This PR uses the code that takes care of correctly labeling SVG (#26) and does the same thing for MathML.