### PR TITLE
Use typeof instead of instanceof.

### DIFF
--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -57,7 +57,7 @@ function createElement(
     : Element {
   let el;
 
-  if (nameOrCtor instanceof Function) {
+  if (typeof nameOrCtor === 'function') {
     el = new nameOrCtor();
   } else {
     const namespace = getNamespaceForTag(nameOrCtor, parent);


### PR DESCRIPTION
This avoids us needing to walk up the prototype chain for custom element
constructors.