### PR TITLE
Add a Closure Compiler output, make it part of dist.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
+build/
 coverage/

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,4 @@
 /**
- * @fileoverview
- * @suppress {extraRequire}
  * @license
  * Copyright 2018 The Incremental DOM Authors. All Rights Reserved.
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -8614,6 +8614,15 @@
         }
       }
     },
+    "jasmine-diff": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/jasmine-diff/-/jasmine-diff-0.1.3.tgz",
+      "integrity": "sha1-k8zC3MQQKMXd1GBlWAdIOfLe6qg=",
+      "dev": true,
+      "requires": {
+        "diff": "3.3.1"
+      }
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -14674,6 +14683,27 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+    },
+    "tsickle": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.32.1.tgz",
+      "integrity": "sha512-JW9j+W0SaMSZGejIFZBk0AiPfnhljK3oLx5SaqxrJhjlvzFyPml5zqG1/PuScUj6yTe1muEqwk5CnDK0cOZmKw==",
+      "dev": true,
+      "requires": {
+        "jasmine-diff": "0.1.3",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map": "0.6.1",
+        "source-map-support": "0.5.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "tsscmp": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "sinon": "^4.0.0",
     "sinon-chai": "^2.9.0",
     "source-map-support": "^0.5.4",
+    "tsickle": "^0.32.1",
     "typescript": "^2.8.1",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "1.1.0",

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -1,6 +1,4 @@
 /**
- * @fileoverview
- * @suppress {extraRequire}
  * @license
  * Copyright 2018 The Incremental DOM Authors. All Rights Reserved.
  *

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -1,6 +1,4 @@
 /**
- * @fileoverview
- * @suppress {extraRequire}
  * @license
  * Copyright 2018 The Incremental DOM Authors. All Rights Reserved.
  *

--- a/src/changes.ts
+++ b/src/changes.ts
@@ -1,6 +1,4 @@
 /**
- * @fileoverview
- * @suppress {extraRequire}
  * @license
  * Copyright 2018 The Incremental DOM Authors. All Rights Reserved.
  *

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,6 +1,4 @@
 /**
- * @fileoverview
- * @suppress {extraRequire}
  * @license
  * Copyright 2018 The Incremental DOM Authors. All Rights Reserved.
  *

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,6 +1,4 @@
 /**
- * @fileoverview
- * @suppress {extraRequire}
  * @license
  * Copyright 2018 The Incremental DOM Authors. All Rights Reserved.
  *

--- a/src/dom_util.ts
+++ b/src/dom_util.ts
@@ -1,6 +1,4 @@
 /**
- * @fileoverview
- * @suppress {extraRequire}
  * @license
  * Copyright 2018 The Incremental DOM Authors. All Rights Reserved.
  *
@@ -16,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import {assert} from './assertions';
 
 /**
  * Checks if the node is the root of a document. This is either a Document

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,6 +1,4 @@
 /**
- * @fileoverview
- * @suppress {extraRequire}
  * @license
  * Copyright 2018 The Incremental DOM Authors. All Rights Reserved.
  *

--- a/src/node_data.ts
+++ b/src/node_data.ts
@@ -1,6 +1,4 @@
 /**
- * @fileoverview
- * @suppress {extraRequire}
  * @license
  * Copyright 2018 The Incremental DOM Authors. All Rights Reserved.
  *

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -1,6 +1,4 @@
 /**
- * @fileoverview
- * @suppress {extraRequire}
  * @license
  * Copyright 2018 The Incremental DOM Authors. All Rights Reserved.
  *

--- a/src/virtual_elements.ts
+++ b/src/virtual_elements.ts
@@ -1,6 +1,4 @@
 /**
- * @fileoverview
- * @suppress {extraRequire}
  * @license
  * Copyright 2018 The Incremental DOM Authors. All Rights Reserved.
  *


### PR DESCRIPTION
This generates a `/closure` folder in dist. The source files are transformed into Closure Compiler annotated code. The index is transformed into `goog.module('incrementaldom')` exporting everything that index.ts exports. Unfortunately, I could not figure out a way to create a single file like the old `incremental-dom-closure.js`.