### PR TITLE
Added Node | ChildNode type to avoid errors caused by update to Types…

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@ Sepand Parhami <sparhami@google.com>
 Justin Ridgewell <justin@ridgewell.name>
 Markus Kobler <markus@distinctive.co>
 Jader Tao <jader@jadert.cn>
+Nick Excell <nick@appzuka.com>

--- a/src/node_data.ts
+++ b/src/node_data.ts
@@ -115,19 +115,12 @@ function importSingleNode(node: Node, fallbackKey?: Key) {
 }
 
 /**
- * In lib.dom.d.ts in typescript v3.03 and before both Node.firstChild and Node.nextSibling were of type Node
- * Starting in v3.1 firstChild is of type ChildNode, causing a type error.  Asserting that the type of child
- * is NodeOrNull allows the code to compile under both versions.
- */
-type NodeOrNull = Node | null;
-
-/**
  * Imports node and its subtree, initializing caches.
  */
 function importNode(node: Node) {
   importSingleNode(node);
 
-  for (let child:NodeOrNull = node.firstChild; child; child = child.nextSibling) {
+  for (let child: Node|null = node.firstChild; child; child = child.nextSibling) {
     importNode(child);
   }
 }
@@ -138,7 +131,7 @@ function importNode(node: Node) {
 function clearCache(node: Node) {
   node['__incrementalDOMData'] = null;
 
-  for (let child:NodeOrNull = node.firstChild; child; child = child.nextSibling) {
+  for (let child: Node|null = node.firstChild; child; child = child.nextSibling) {
     clearCache(child);
   }
 }

--- a/src/node_data.ts
+++ b/src/node_data.ts
@@ -116,10 +116,10 @@ function importSingleNode(node: Node, fallbackKey?: Key) {
 
 /**
  * In lib.dom.d.ts in typescript v3.03 and before both Node.firstChild and Node.nextSibling were of type Node
- * Starting in v3.1 firstChild is of type ChildNode, causing a type error.  Declaring type NodeOrChild as
- * a union type allows the code to compile under both versions.
+ * Starting in v3.1 firstChild is of type ChildNode, causing a type error.  Asserting that the type of child
+ * is NodeOrNull allows the code to compile under both versions.
  */
-type NodeOrChild = ChildNode | Node | null;
+type NodeOrNull = Node | null;
 
 /**
  * Imports node and its subtree, initializing caches.
@@ -127,7 +127,7 @@ type NodeOrChild = ChildNode | Node | null;
 function importNode(node: Node) {
   importSingleNode(node);
 
-  for (let child:NodeOrChild = node.firstChild; child; child = child.nextSibling) {
+  for (let child:NodeOrNull = node.firstChild; child; child = child.nextSibling) {
     importNode(child);
   }
 }
@@ -138,7 +138,7 @@ function importNode(node: Node) {
 function clearCache(node: Node) {
   node['__incrementalDOMData'] = null;
 
-  for (let child:NodeOrChild = node.firstChild; child; child = child.nextSibling) {
+  for (let child:NodeOrNull = node.firstChild; child; child = child.nextSibling) {
     clearCache(child);
   }
 }

--- a/src/node_data.ts
+++ b/src/node_data.ts
@@ -115,12 +115,19 @@ function importSingleNode(node: Node, fallbackKey?: Key) {
 }
 
 /**
+ * In lib.dom.d.ts in typescript v3.03 and before both Node.firstChild and Node.nextSibling were of type Node
+ * Starting in v3.1 firstChild is of type ChildNode, causing a type error.  Declaring type NodeOrChild as
+ * a union type allows the code to compile under both versions.
+ */
+type NodeOrChild = ChildNode | Node | null;
+
+/**
  * Imports node and its subtree, initializing caches.
  */
 function importNode(node: Node) {
   importSingleNode(node);
 
-  for (let child = node.firstChild; child; child = child.nextSibling) {
+  for (let child:NodeOrChild = node.firstChild; child; child = child.nextSibling) {
     importNode(child);
   }
 }
@@ -131,11 +138,10 @@ function importNode(node: Node) {
 function clearCache(node: Node) {
   node['__incrementalDOMData'] = null;
 
-  for (let child = node.firstChild; child; child = child.nextSibling) {
+  for (let child:NodeOrChild = node.firstChild; child; child = child.nextSibling) {
     clearCache(child);
   }
 }
-
 
 /**
  * Records the element's attributes.


### PR DESCRIPTION
In lib.dom.d.ts in typescript v3.03 and before both Node.firstChild and Node.nextSibling were of type Node. Starting in v3.1 firstChild is of type ChildNode, causing a type error.  Declaring type NodeOrChild as a union type allows the code to compile under both versions.