### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: node_js
 sudo: required
 dist: trusty
 node_js:
+  - 6
   - 8
+  - 10
+  - node
 before_install:
   - export CHROME_BIN=google-chrome
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ before_install:
   - sudo dpkg -i google-chrome*.deb
 # This is basically redundant (ends up getting run twice) as this gets called
 # by npm on install due to the prepublish script in package.json.
+install: npm install
 script:
   - gulp dist


### PR DESCRIPTION
Test on Node.js 6, 8, 10 and 11 as these are LTS and stable. See https://github.com/nodejs/Release/blob/master/README.md