### PR TITLE
Update to latest bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,61 @@
+# Common Bazel settings for JavaScript/NodeJS workspaces
+# This rc file is automatically discovered when Bazel is run in this workspace,
+# see https://docs.bazel.build/versions/master/guide.html#bazelrc
+#
+# The full list of Bazel options: https://docs.bazel.build/versions/master/command-line-reference.html
+
+# Bazel will create symlinks from the workspace directory to output artifacts.
+# Build results will be placed in a directory called "dist/bin"
+# Other directories will be created like "dist/testlogs"
+# Be aware that this will still create a bazel-out symlink in
+# your project directory, which you must exclude from version control and your
+# editor's search path.
+build --symlink_prefix=dist/
+# To disable the symlinks altogether (including bazel-out) you can use
+# build --symlink_prefix=/
+# however this makes it harder to find outputs.
+
+# Specifies desired output mode for running tests.
+# Valid values are
+#   'summary' to output only test status summary
+#   'errors' to also print test logs for failed tests
+#   'all' to print logs for all tests
+#   'streamed' to output logs for all tests in real time
+#     (this will force tests to be executed locally one at a time regardless of --test_strategy value).
+test --test_output=errors
+
+# Support for debugging NodeJS tests
+# Add the Bazel option `--config=debug` to enable this
+test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results
+
+# Turn off legacy external runfiles
+# This prevents accidentally depending on this feature, which Bazel will remove.
+run --nolegacy_external_runfiles
+test --nolegacy_external_runfiles
+
+# Prevent TypeScript worker seeing files not declared as inputs
+build --worker_sandboxing
+
+# Turn on the "Managed Directories" feature.
+# This allows Bazel to share the same node_modules directory with other tools
+# NB: this option was introduced in Bazel 0.26
+# See https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_allow_incremental_repository_updates
+common --experimental_allow_incremental_repository_updates
+
+# Turn on --incompatible_strict_action_env which was on by default
+# in Bazel 0.21.0 but turned off again in 0.22.0. Follow
+# https://github.com/bazelbuild/bazel/issues/7026 for more details.
+# This flag is needed to so that the bazel cache is not invalidated
+# when running bazel via `yarn bazel`.
+# See https://github.com/angular/angular/issues/27514.
+build --incompatible_strict_action_env
+run --incompatible_strict_action_env
+
+# Load any settings specific to the current user.
+# .bazelrc.user should appear in .gitignore so that settings are not shared with team members
+# This needs to be last statement in this
+# config, as the user configuration should be able to overwrite flags from this file.
+# See https://docs.bazel.build/versions/master/best-practices.html#bazelrc
+# (Note that we use .bazelrc.user so the file appears next to .bazelrc in directory listing,
+# rather than user.bazelrc as suggested in the Bazel docs)
+try-import %workspace%/.bazelrc.user

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//:__subpackages__"])
 
 load("@npm_bazel_typescript//:defs.bzl", "ts_devserver", "ts_library")
 
@@ -12,6 +12,6 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
 
 rollup_bundle(
   name = "bundle",
-  entry_point = "index.js",
+  entry_point = ":index.ts",
   deps = [":app"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,12 +1,15 @@
-workspace(name = 'lang')
+workspace(
+    name = 'incremental_dom',
+    managed_directories = {"@npm": ["node_modules"]},
+)
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Fetch rules_nodejs so we can install our npm dependencies
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "1db950bbd27fb2581866e307c0130983471d4c3cd49c46063a2503ca7b6770a4",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.29.0/rules_nodejs-0.29.0.tar.gz"],
+    sha256 = "6d4edbf28ff6720aedf5f97f9b9a7679401bf7fca9d14a0fff80f644a99992b4",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.32.2/rules_nodejs-0.32.2.tar.gz"],
 )
 
 # Check the bazel version and download npm dependencies
@@ -17,10 +20,10 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "npm_install
 #            (see https://github.com/angular/angular/issues/27514#issuecomment-451438271)
 check_bazel_version(
     message = """
-You no longer need to install Bazel on your machine.
+You don't need to install Bazel on your machine.
 Angular has a dependency on the @bazel/bazel package which supplies it.
-Try running `yarn bazel` instead.
-    (If you did run that, check that you've got a fresh `yarn install`)
+Try running `npm run bazel` instead.
+    (If you did run that, check that you've got a fresh `npm install`)
 """,
     minimum_bazel_version = "0.21.0",
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,43 +5,43 @@
   "requires": true,
   "dependencies": {
     "@bazel/bazel": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@bazel/bazel/-/bazel-0.25.1.tgz",
-      "integrity": "sha512-HM2IsX9M4siW8b2AHZP4ixtT1NH9H74M0/DJfh0hr15NlivTapvkVQSfEfW57CCMfkuMcDjvfJQK+KzfuVyMgw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@bazel/bazel/-/bazel-0.27.0.tgz",
+      "integrity": "sha512-yIj64IkesNzjHsoeehQUMBOgrCK/JMSuon5CvBqo6+izPXAmt+OW05uqaLL/FPAYAFQ2mHxsYtDsPxsM8DUbqA==",
       "dev": true,
       "requires": {
-        "@bazel/bazel-darwin_x64": "0.25.1",
-        "@bazel/bazel-linux_x64": "0.25.1",
-        "@bazel/bazel-win32_x64": "0.25.1"
+        "@bazel/bazel-darwin_x64": "0.27.0",
+        "@bazel/bazel-linux_x64": "0.27.0",
+        "@bazel/bazel-win32_x64": "0.27.0"
       },
       "dependencies": {
         "@bazel/bazel-darwin_x64": {
-          "version": "0.25.1",
-          "resolved": "https://registry.npmjs.org/@bazel/bazel-darwin_x64/-/bazel-darwin_x64-0.25.1.tgz",
-          "integrity": "sha512-VYPHaXZFlyl/1MOnUdByusox0RataI+dvQ37FiuuK9byFlcgCoIvhAx20nLK56tEhi/obXXaG2AO4w6rfOcgWg==",
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@bazel/bazel-darwin_x64/-/bazel-darwin_x64-0.27.0.tgz",
+          "integrity": "sha512-CyavIbRKRa/55aMyfEM9hjbt4TVISfv7HLeymHTGTLWzS8uQokQ8W9tR/pgc7YJn8F0x64dd7nQKxhbYHM1Qfg==",
           "dev": true,
           "optional": true
         },
         "@bazel/bazel-linux_x64": {
-          "version": "0.25.1",
-          "resolved": "https://registry.npmjs.org/@bazel/bazel-linux_x64/-/bazel-linux_x64-0.25.1.tgz",
-          "integrity": "sha512-i+b6RSWn5qGZlrcct+lpWVHd3sen7UaBqQyi/0Rn+J72XCIbY2AFoi+j6SlCXb3EFltxJBCHKJHZqEtkP79bDQ==",
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@bazel/bazel-linux_x64/-/bazel-linux_x64-0.27.0.tgz",
+          "integrity": "sha512-hO04v7C6M3Jf+qNlLE+IticZZKkkS7Nv6+pXDnENgFWrqLV2H93un6kNQnk83B0hP2cEqRQ8rw5yrIcqXNNuSQ==",
           "dev": true,
           "optional": true
         },
         "@bazel/bazel-win32_x64": {
-          "version": "0.25.1",
-          "resolved": "https://registry.npmjs.org/@bazel/bazel-win32_x64/-/bazel-win32_x64-0.25.1.tgz",
-          "integrity": "sha512-LM/rY8cxioCFe0m6WxdfvZ6pbD9eKzp69C1BhIkoESyp0IDLDvnLJ6uvs722e3hl8Zj1sIEIbiCwrYk33lPkTg==",
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@bazel/bazel-win32_x64/-/bazel-win32_x64-0.27.0.tgz",
+          "integrity": "sha512-7hIGNhdgaxRt9ceSOCs3eSTtCNi4GXz3nu6OjfgSp+QiqLbW/iAVWa8M8vD5aemZ1BSHek4/LISdWUTncLJk+w==",
           "dev": true,
           "optional": true
         }
       }
     },
     "@bazel/typescript": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@bazel/typescript/-/typescript-0.29.0.tgz",
-      "integrity": "sha512-Dp5ucrE1vXTORGiwEi6Ur4dlICpLsmZ1dscsEQT4ywF7xTT0/NmIG0ecBghiCFPFQTxt1D05TR3SH06rPtTAew==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@bazel/typescript/-/typescript-0.32.2.tgz",
+      "integrity": "sha512-32zDyvHdYjIa63vtImhl6wy5ErOFVWPkjMT2T035D0UPSKI1tvENW/bRZ3QFlFHqfmJZRBpaI3GiUpO3vUvzmw==",
       "dev": true,
       "requires": {
         "protobufjs": "6.8.8",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "bazel": "bazel build :bundle"
   },
   "devDependencies": {
+    "@bazel/bazel": "^0.27.0",
+    "@bazel/typescript": "^0.32.2",
     "@types/mocha": "^5.0.0",
     "@types/sinon": "^4.3.0",
     "@types/sinon-chai": "^2.7.29",
@@ -66,9 +68,7 @@
     "typescript": "~3.4.1",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "2.0.0",
-    "webcomponents.js": "0.7.2",
-    "@bazel/bazel": "^0.25.1",
-    "@bazel/typescript": "0.29.0"
+    "webcomponents.js": "0.7.2"
   },
   "dependencies": {
     "npm-check": "^5.6.0"

--- a/src/BUILD
+++ b/src/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//:__subpackages__"])
 
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
 


### PR DESCRIPTION
Introduce a .bazelrc with useful settings
Use the managed_directories feature so bazel doesn't download a second copy of dependencies
Also clean up build visibility (don't want other projects that reference this workspace to see the targets)