### PR TITLE
Separate out attribute updates from element open.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,5 +21,5 @@ export {setKeyAttributeName} from './src/global';
 export {clearCache,getKey, importNode, isDataInitialized} from './src/node_data';
 export {notifications} from './src/notifications';
 export {symbols} from './src/symbols';
-export {attr, elementClose, elementOpen, elementOpenEnd, elementOpenStart, elementVoid, key, text} from './src/virtual_elements';
+export {applyAttrs, applyStatics, attr, elementClose, elementOpen, elementOpenEnd, elementOpenStart, elementVoid, key, text} from './src/virtual_elements';
 export * from './src/types';

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -32,12 +32,17 @@ let inAttributes = false;
  */
 let inSkip = false;
 
+/**
+ * Keeps track of the current patch context.
+ */
+let patchContext: {}|null = null;
+
 
 /**
  * Makes sure that there is a current patch context.
  */
-function assertInPatch(functionName: string, context: Document) {
-  if (!context) {
+function assertInPatch(functionName: string) {
+  if (!patchContext) {
     throw new Error('Cannot call ' + functionName + '() unless in patch.');
   }
 }
@@ -183,6 +188,14 @@ function assertPatchElementNoExtras(
 
 
 /**
+ * @param newContext The current patch context.
+ */
+function updatePatchContext(newContext: {}|null) {
+  patchContext = newContext;
+}
+
+
+/**
  * Updates the state of being in an attribute declaration.
  * @return the previous value.
  */
@@ -229,4 +242,5 @@ export {
   assertPatchOuterHasParentNode,
   setInAttributes,
   setInSkip,
+  updatePatchContext,
 };

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -33,16 +33,16 @@ let inAttributes = false;
 let inSkip = false;
 
 /**
- * Keeps track of the current patch context.
+ * Keeps track of whether or not we are in a patch.
  */
-let patchContext: {}|null = null;
+let inPatch: boolean = false;
 
 
 /**
  * Makes sure that there is a current patch context.
  */
 function assertInPatch(functionName: string) {
-  if (!patchContext) {
+  if (!inPatch) {
     throw new Error('Cannot call ' + functionName + '() unless in patch.');
   }
 }
@@ -191,7 +191,7 @@ function assertPatchElementNoExtras(
  * @param newContext The current patch context.
  */
 function updatePatchContext(newContext: {}|null) {
-  patchContext = newContext;
+  inPatch = newContext != null;
 }
 
 

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -16,8 +16,9 @@
  */
 
 import {AttrMutatorConfig} from './types';
-import {symbols} from './symbols';
+import {assert} from './assertions';
 import {createMap, has} from './util';
+import {symbols} from './symbols';
 
 
 /**
@@ -90,12 +91,15 @@ function setStyleValue(
  *     containing property-value pairs.
  */
 function applyStyle(
-    el: HTMLElement, name: string, style: string|{[k: string]: string}) {
+    el: Element, name: string, style: string|{[k: string]: string}) {
+  // MathML elements inherit from Element, which does not have style.
+  assert(el instanceof HTMLElement || el instanceof SVGElement);
+  const elStyle = (<HTMLElement|SVGElement>el).style;
+
   if (typeof style === 'string') {
-    el.style.cssText = style;
+    elStyle.cssText = style;
   } else {
-    el.style.cssText = '';
-    const elStyle = el.style;
+    elStyle.cssText = '';
 
     for (const prop in style) {
       if (has(style, prop)) {
@@ -114,7 +118,7 @@ function applyStyle(
  *     function it is set on the Element, otherwise, it is set as an HTML
  *     attribute.
  */
-function applyAttributeTyped(el: HTMLElement, name: string, value: {}) {
+function applyAttributeTyped(el: Element, name: string, value: {}) {
   const type = typeof value;
 
   if (type === 'object' || type === 'function') {
@@ -141,8 +145,7 @@ attributes['style'] = applyStyle;
 /**
  * Calls the appropriate attribute mutator for this attribute.
  */
-function updateAttribute(
-    el: HTMLElement, name: string, value: {}|null|undefined) {
+function updateAttribute(el: Element, name: string, value: {}|null|undefined) {
   const mutator = attributes[name] || attributes[symbols.default];
   mutator(el, name, value);
 }

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -42,8 +42,7 @@ function getNamespace(name: string): string|undefined {
  * or undefined, it is removed from the Element. Otherwise, the value is set
  * as an attribute.
  */
-// tslint:disable-next-line:no-any
-function applyAttr(el: Element, name: string, value: any) {
+function applyAttr(el: Element, name: string, value: unknown) {
   if (value == null) {
     el.removeAttribute(name);
   } else {
@@ -59,8 +58,7 @@ function applyAttr(el: Element, name: string, value: any) {
 /**
  * Applies a property to a given Element.
  */
-// tslint:disable-next-line:no-any
-function applyProp(el: Element, name: string, value: any) {
+function applyProp(el: Element, name: string, value: unknown) {
   // tslint:disable-next-line:no-any
   (el as any)[name] = value;
 }
@@ -118,7 +116,7 @@ function applyStyle(
  *     function it is set on the Element, otherwise, it is set as an HTML
  *     attribute.
  */
-function applyAttributeTyped(el: Element, name: string, value: {}) {
+function applyAttributeTyped(el: Element, name: string, value: unknown) {
   const type = typeof value;
 
   if (type === 'object' || type === 'function') {
@@ -145,7 +143,7 @@ attributes['style'] = applyStyle;
 /**
  * Calls the appropriate attribute mutator for this attribute.
  */
-function updateAttribute(el: Element, name: string, value: {}|null|undefined) {
+function updateAttribute(el: Element, name: string, value: unknown) {
   const mutator = attributes[name] || attributes[symbols.default];
   mutator(el, name, value);
 }

--- a/src/changes.ts
+++ b/src/changes.ts
@@ -28,7 +28,7 @@ let bufferStart = 0;
  * TODO(tomnguyen): This is a bit silly and really needs to be better typed.
  */
 function queueChange<A, B, C>(
-    fn: (a: A, b: B, c: C) => undefined, a: A, b: B, c: C) {
+    fn: (a: A, b: B, c: C) => void, a: A, b: B, c: C) {
   buffer.push(fn);
   buffer.push(a);
   buffer.push(b);

--- a/src/core.ts
+++ b/src/core.ts
@@ -57,7 +57,7 @@ function getArgsBuilder(): Array<{}|null|undefined> {
 
 
 /**
- * TODO(sparhami) We should just export argsBuilder directly when Closure
+ * TODO(sparhami) We should just export attrsBuilder directly when Closure
  * Compiler supports ES6 directly.
  */
 function getAttrsBuilder(): Array<any> {

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -17,6 +17,7 @@
 
 
 import {createMap, truncateArray} from './util';
+import {flush, queueChange} from './changes';
 
 
 /**
@@ -38,7 +39,7 @@ const prevValuesMap = createMap();
  */
 function calculateDiff<T>(
     prev: string[], next: string[], updateCtx: T,
-    updateFn: (ctx: T, x: string, y: {}|undefined) => undefined) {
+    updateFn: (ctx: T, x: string, y: {}|undefined) => void) {
   const isNew = !prev.length;
   let i = 0;
 
@@ -53,7 +54,7 @@ function calculateDiff<T>(
     const value = next[i + 1];
     if (isNew || prev[i + 1] !== value) {
       prev[i + 1] = value;
-      updateFn(updateCtx, name, value);
+      queueChange(updateFn, updateCtx, name, value);
     }
   }
 
@@ -71,7 +72,7 @@ function calculateDiff<T>(
       const value = next[i + 1];
 
       if (prevValuesMap[name] !== value) {
-        updateFn(updateCtx, name, value);
+        queueChange(updateFn, updateCtx, name, value);
       }
 
       prev[i] = name;
@@ -83,10 +84,12 @@ function calculateDiff<T>(
     truncateArray(prev, next.length);
 
     for (const name in prevValuesMap) {
-      updateFn(updateCtx, name, undefined);
+      queueChange(updateFn, updateCtx, name, undefined);
       delete prevValuesMap[name];
     }
   }
+
+  flush();
 }
 
 

--- a/src/node_data.ts
+++ b/src/node_data.ts
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-import {assert} from './assertions';
-import {isElement, isText} from './dom_util';
-import {getKeyAttributeName} from './global';
 import {Key, NameOrCtorDef} from './types';
+import {assert} from './assertions';
+import {createArray} from './util';
+import {isElement} from './dom_util';
+import {getKeyAttributeName} from './global';
 
 
 /**
@@ -63,7 +64,7 @@ export class NodeData {
   }
 
   getAttrsArr(length: number): any[] {
-    return this._attrsArr || (this._attrsArr = new Array(length));
+    return this._attrsArr || (this._attrsArr = createArray(length));
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@
 export interface ElementConstructor {new(): Element};
 
 // tslint:disable-next-line:no-any
-export type AttrMutator = (a: HTMLElement, b: string, c: any) => void;
+export type AttrMutator = (a: Element, b: string, c: any) => void;
 
 export type AttrMutatorConfig = {[x: string]: AttrMutator};
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -62,4 +62,20 @@ function truncateArray(arr: Array<{}|null|undefined>, length: number) {
   }
 }
 
-export {createMap, has, truncateArray,};
+
+/**
+ * Creates an array for a desired initial size. Note that the array will still
+ * be empty.
+ */
+function createArray<T>(initialAllocationSize: number): Array<T> {
+  const arr = new Array(initialAllocationSize);
+  truncateArray(arr, 0);
+  return arr;
+}
+
+export {
+  createArray,
+  createMap,
+  has,
+  truncateArray,
+};

--- a/src/virtual_elements.ts
+++ b/src/virtual_elements.ts
@@ -190,7 +190,6 @@ function key(key:string) {
   argsBuilder[1] = key;
 }
 
-
 /***
  * Buffers an attribute, which will get applied during the next call to
  * `elementOpen`, `elementOpenEnd` or `applyAttrs`.
@@ -243,14 +242,14 @@ function applyAttrs() {
 
 /**
  * Applies the current static attributes to the currently open element. Note:
- * statics should be applied before apply attrs.
+ * statics should be applied before calling `applyAtrs`.
+ * @param statics The statics to apply to the current element.
  */
-function applyStatics() {
-  const argsBuilder = getArgsBuilder();
+function applyStatics(statics: Statics) {
   const node = currentElement();
   const data = getData(node);
 
-  diffStatics(node, data, <Statics>argsBuilder[2]);
+  diffStatics(node, data, statics);
 }
 
 

--- a/test/functional/applyStatics.ts
+++ b/test/functional/applyStatics.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2018 The Incremental DOM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {applyStatics, close, open, patch} from '../../index';
+const {expect} = chai;
+
+ /**
+ * @param container
+ */
+function createMutationObserver(container: Element): MutationObserver {
+  const mo = new MutationObserver(() => {});
+  mo.observe(container, {
+    attributes: true,
+    subtree: true,
+  });
+
+  return mo;
+}
+
+describe('applyStatics', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('should add attributes to the current element when created', () => {
+    patch(container, () => {
+      open('div');
+      applyStatics(['nameOne', 'valueOne', 'nameTwo', 'valueTwo']);
+      close();
+    });
+
+    const firstChild = container.children[0];
+    expect(firstChild.attributes).to.have.length(2);
+    expect(firstChild.getAttribute('nameOne')).to.equal('valueOne');
+    expect(firstChild.getAttribute('nameTwo')).to.equal('valueTwo');
+  });
+
+  it('should add attributes if called after a subtree', () => {
+    patch(container, () => {
+      open('div');
+      open('span');
+      close();
+
+      applyStatics(['nameOne', 'valueOne', 'nameTwo', 'valueTwo']);
+      close();
+    });
+
+    const firstChild = container.children[0];
+    expect(firstChild.attributes).to.have.length(2);
+    expect(firstChild.getAttribute('nameOne')).to.equal('valueOne');
+    expect(firstChild.getAttribute('nameTwo')).to.equal('valueTwo');
+  });
+
+  it('should not re-apply if the statics changed', () => {
+    patch(container, () => {
+      open('div');
+      applyStatics(['nameOne', 'valueOne', 'nameTwo', 'valueTwo']);
+      close();
+    });
+
+    const mo = createMutationObserver(container);
+
+    patch(container, () => {
+      open('div');
+      applyStatics(['nameOne', 'valueOneNew', 'nameThree', 'valueThree']);
+      close();
+    });
+
+    expect(mo.takeRecords()).to.be.empty;
+  });
+});

--- a/test/functional/attributes.ts
+++ b/test/functional/attributes.ts
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 
-// taze: Sinon.chai from //third_party/javascript/typings/Sinon.chai
-// taze: mocha from //third_party/javascript/typings/mocha
-// taze: chai from //third_party/javascript/typings/chai
-
 import {attr, elementClose, elementOpen, elementOpenEnd, elementOpenStart, elementVoid, importNode, patch} from '../../index';
 const {expect} = chai;
 

--- a/test/functional/buffered_attributes.ts
+++ b/test/functional/buffered_attributes.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2018 The Incremental DOM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {applyAttrs, attr, close, open, patch} from '../../index';
+const {expect} = chai;
+
+describe('buffered attributes', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('should add attributes to the current element', () => {
+    patch(container, () => {
+      open('div');
+      // Attrs below will still apply to the current pointer, even though
+      // another element was opened/closed in the mean time.
+      open('span');
+      close();
+
+      attr('nameOne', 'valueOne');
+      attr('nameTwo', 'valueTwo');
+      applyAttrs();
+      close();
+
+      open('div');
+      attr('nameThree', 'valueThree');
+      applyAttrs();
+      close();
+    });
+
+    const firstChild = container.children[0];
+    const secondChild = container.children[1];
+    expect(firstChild.attributes).to.have.length(2);
+    expect(firstChild.getAttribute('nameOne')).to.equal('valueOne');
+    expect(firstChild.getAttribute('nameTwo')).to.equal('valueTwo');
+    expect(secondChild.attributes).to.have.length(1);
+    expect(secondChild.getAttribute('nameThree')).to.equal('valueThree');
+  });
+  
+  it('should not be left over between patches', () => {
+    patch(container, () => {
+      attr('nameOne', 'valueOne');
+      attr('nameTwo', 'valueTwo');
+    });
+
+    patch(container, () => {
+      open('div');
+      attr('nameThree', 'valueThree');
+      applyAttrs();
+      close();
+    });
+
+    const firstChild = container.children[0];
+    expect(firstChild.attributes).to.have.length(1);
+    expect(firstChild.getAttribute('nameThree')).to.equal('valueThree');
+  });
+
+  it('should not carry over to nested patches', () => {
+    const secondContainer = document.createElement('div');
+
+    patch(container, () => {
+      attr('nameOne', 'valueOne');
+      attr('nameTwo', 'valueTwo');
+
+      patch(secondContainer, () => {
+        open('div');
+        attr('nameThree', 'valueThree');
+        applyAttrs();
+        close();
+      });
+    });
+
+    const firstChild = secondContainer.children[0];
+    expect(firstChild.attributes).to.have.length(1);
+    expect(firstChild.getAttribute('nameThree')).to.equal('valueThree');
+  });
+
+  it('should restore after nested patches', () => {
+    const secondContainer = document.createElement('div');
+
+    patch(container, () => {
+      attr('nameOne', 'valueOne');
+      attr('nameTwo', 'valueTwo');
+
+      patch(secondContainer, () => {
+        open('div');
+        attr('nameThree', 'valueThree');
+        applyAttrs();
+        close();
+      });
+
+      open('div');
+      applyAttrs();
+      close();
+    });
+
+    const firstChild = container.children[0];
+    expect(firstChild.attributes).to.have.length(2);
+    expect(firstChild.getAttribute('nameOne')).to.equal('valueOne');
+    expect(firstChild.getAttribute('nameTwo')).to.equal('valueTwo');
+  });
+});

--- a/test/functional/buffered_attributes.ts
+++ b/test/functional/buffered_attributes.ts
@@ -33,11 +33,6 @@ describe('buffered attributes', () => {
   it('should add attributes to the current element', () => {
     patch(container, () => {
       open('div');
-      // Attrs below will still apply to the current pointer, even though
-      // another element was opened/closed in the mean time.
-      open('span');
-      close();
-
       attr('nameOne', 'valueOne');
       attr('nameTwo', 'valueTwo');
       applyAttrs();
@@ -56,6 +51,24 @@ describe('buffered attributes', () => {
     expect(firstChild.getAttribute('nameTwo')).to.equal('valueTwo');
     expect(secondChild.attributes).to.have.length(1);
     expect(secondChild.getAttribute('nameThree')).to.equal('valueThree');
+  });
+
+  it('should add attributes even when a subtree has been open/closed', () => {
+    patch(container, () => {
+      open('div');
+      open('span');
+      close();
+
+      attr('nameOne', 'valueOne');
+      attr('nameTwo', 'valueTwo');
+      applyAttrs();
+      close();
+    });
+
+    const firstChild = container.children[0];
+    expect(firstChild.attributes).to.have.length(2);
+    expect(firstChild.getAttribute('nameOne')).to.equal('valueOne');
+    expect(firstChild.getAttribute('nameTwo')).to.equal('valueTwo');
   });
   
   it('should not be left over between patches', () => {

--- a/test/functional/conditional_rendering.ts
+++ b/test/functional/conditional_rendering.ts
@@ -15,9 +15,6 @@
  * limitations under the License.
  */
 
-// taze: mocha from //third_party/javascript/typings/mocha
-// taze: chai from //third_party/javascript/typings/chai
-
 import {elementClose, elementOpen, elementVoid, patch} from '../../index';
 import {assertHTMLElement,} from '../util/dom';
 const {expect} = chai;

--- a/test/functional/constructors.ts
+++ b/test/functional/constructors.ts
@@ -15,9 +15,6 @@
  * limitations under the License.
  */
 
-// taze: mocha from //third_party/javascript/typings/mocha
-// taze: chai from //third_party/javascript/typings/chai
-
 import * as Sinon from 'sinon';
 
 import {close, open, patch} from '../../index';

--- a/test/functional/currentElement.ts
+++ b/test/functional/currentElement.ts
@@ -15,12 +15,6 @@
  * limitations under the License.
  */
 
-
-// taze: Sinon.chai from //third_party/javascript/typings/Sinon.chai
-// taze: mocha from //third_party/javascript/typings/mocha
-// taze: chai from //third_party/javascript/typings/chai
-
-
 import {currentElement, elementClose, elementOpen, elementOpenEnd, elementOpenStart, elementVoid, patch} from '../../index';
 const {expect} = chai;
 

--- a/test/functional/currentPointer.ts
+++ b/test/functional/currentPointer.ts
@@ -15,9 +15,6 @@
  * limitations under the License.
  */
 
-// taze: mocha from //third_party/javascript/typings/mocha
-// taze: chai from //third_party/javascript/typings/chai
-
 import {currentPointer, elementClose, elementOpenEnd, elementOpenStart, elementVoid, patch} from '../../index';
 import {assertHTMLElement,} from '../util/dom';
 const {expect} = chai;

--- a/test/functional/element_creation.ts
+++ b/test/functional/element_creation.ts
@@ -15,9 +15,6 @@
  * limitations under the License.
  */
 
-// taze: mocha from //third_party/javascript/typings/mocha
-// taze: chai from //third_party/javascript/typings/chai
-
 import * as Sinon from 'sinon';
 
 import {elementClose, elementOpen, elementOpenEnd, elementOpenStart, elementVoid, patch} from '../../index';

--- a/test/functional/errors.ts
+++ b/test/functional/errors.ts
@@ -15,9 +15,6 @@
  * limitations under the License.
  */
 
-// taze: mocha from //third_party/javascript/typings/mocha
-// taze: chai from //third_party/javascript/typings/chai
-
 import * as Sinon from 'sinon';
 
 import {attr, currentElement, elementClose, elementOpen, elementOpenEnd, elementOpenStart, elementVoid, patch} from '../../index';

--- a/test/functional/formatters.ts
+++ b/test/functional/formatters.ts
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 
-// taze: Sinon.chai from //third_party/javascript/typings/Sinon.chai
-// taze: mocha from //third_party/javascript/typings/mocha
-// taze: chai from //third_party/javascript/typings/chai
-
 import * as Sinon from 'sinon';
 
 import {patch, text} from '../../index';

--- a/test/functional/hooks.ts
+++ b/test/functional/hooks.ts
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 
-// taze: Sinon.chai from //third_party/javascript/typings/Sinon.chai
-// taze: mocha from //third_party/javascript/typings/mocha
-// taze: chai from //third_party/javascript/typings/chai
-
 import * as Sinon from 'sinon';
 
 import {attributes, elementVoid, notifications, patch, symbols, text} from '../../index';

--- a/test/functional/virtual_attributes.ts
+++ b/test/functional/virtual_attributes.ts
@@ -91,16 +91,6 @@ describe('virtual attribute updates', () => {
       expect(childAttributes).to.have.length(1);
       expect(childAttributes['childAttrOne'].value).to.equal('cOne');
     });
-
-    it('should throw when defined outside virtual attributes element', () => {
-      expect(() => {
-        patch(container, () => {
-          attr('data-expanded', true);
-        });
-      })
-          .to.throw(
-              'attr() can only be called after calling elementOpenStart().');
-    });
   });
 
   it('should throw when a virtual attributes element is unclosed', () => {


### PR DESCRIPTION
- Change elementOpen to use elementOpenStart flow since there is basically no
  performance hit and elementOpenStart is used a lot in practice (e.g.
  when creating a wrapper that uses an Object for attributes).
- Fix attribute mutator type to be Element.
- Add `applyStatics` function, which can be used with `open`.
- Add `applyAttrs` function, which can be used with `open` and calls to `attr`.
- Fix code flow for diff.js to account for arrays that are initialized with a
  size.