### PR TITLE
pin type of patchInner/patchOuter

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -465,8 +465,8 @@ function createPatchOuter<T>(
   }, patchConfig);
 }
 
-const patchInner = createPatchInner();
-const patchOuter = createPatchOuter();
+const patchInner: PatchFunction<{}, Node> = createPatchInner();
+const patchOuter: PatchFunction<{}, Node|null> = createPatchOuter();
 
 export {
   alignWithDOM,

--- a/src/core.ts
+++ b/src/core.ts
@@ -466,7 +466,7 @@ function createPatchOuter<T>(
 }
 
 const patchInner: PatchFunction<{}, Node> = createPatchInner();
-const patchOuter: PatchFunction<{}, Node|null> = createPatchOuter();
+const patchOuter: PatchFunction<{}, Node | null> = createPatchOuter();
 
 export {
   alignWithDOM,


### PR DESCRIPTION
Though createPatchInner etc are defined in terms of generics,
the resulting values saved here (patchInner/patchOuter) have
inexpressible types.  You'd want something like:
  const patchInner: <T>PatchFunction<T, Node>;
but that is not legal TS syntax.

What happens instead is in the d.ts, TS just chooses an
arbitrary T and all callers get that instead.  In TS3.4
the T is {} and in 3.5 it's unknown and that makes the
callers unhappy.  So this change pins this code to the
TS3.4 behavior.