### PR TITLE
Duplicate type definition for patch methods

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -465,8 +465,12 @@ function createPatchOuter<T>(
   }, patchConfig);
 }
 
-const patchInner: PatchFunction<{}, Node> = createPatchInner();
-const patchOuter: PatchFunction<{}, Node | null> = createPatchOuter();
+const patchInner: <T, R>(
+    node: Element|DocumentFragment, template: (a: T|undefined) => void,
+    data?: T|undefined) => R = createPatchInner();
+const patchOuter: <T, R>(
+    node: Element|DocumentFragment, template: (a: T|undefined) => void,
+    data?: T|undefined) => R = createPatchOuter();
 
 export {
   alignWithDOM,

--- a/src/core.ts
+++ b/src/core.ts
@@ -465,12 +465,12 @@ function createPatchOuter<T>(
   }, patchConfig);
 }
 
-const patchInner: <T, R>(
+const patchInner: <T>(
     node: Element|DocumentFragment, template: (a: T|undefined) => void,
-    data?: T|undefined) => R = createPatchInner();
-const patchOuter: <T, R>(
+    data?: T|undefined) => Node = createPatchInner();
+const patchOuter: <T>(
     node: Element|DocumentFragment, template: (a: T|undefined) => void,
-    data?: T|undefined) => R = createPatchOuter();
+    data?: T|undefined) => Node|null = createPatchOuter();
 
 export {
   alignWithDOM,

--- a/src/core.ts
+++ b/src/core.ts
@@ -465,13 +465,13 @@ function createPatchOuter<T>(
   }, patchConfig);
 }
 
-const patchInner: < T > (
-	node: Element | DocumentFragment,
-	template: (a: T | undefined) => void,
-	data ? : T | undefined) => Node = createPatchInner();
-const patchOuter: < T > (
-	node: Element | DocumentFragment, template: (a: T | undefined) => void,
-	data ? : T | undefined) => Node | null = createPatchOuter();
+const patchInner: <T> (
+        node: Element | DocumentFragment,
+        template: (a: T | undefined) => void,
+        data? : T | undefined) => Node = createPatchInner();
+const patchOuter: <T> (
+        node: Element | DocumentFragment, template: (a: T | undefined) => void,
+        data? : T | undefined) => Node | null = createPatchOuter();
 
 export {
   alignWithDOM,

--- a/src/core.ts
+++ b/src/core.ts
@@ -465,12 +465,13 @@ function createPatchOuter<T>(
   }, patchConfig);
 }
 
-const patchInner: <T>(
-    node: Element | DocumentFragment, template: (a: T | undefined) => void,
-    data?: T | undefined) => Node = createPatchInner();
-const patchOuter: <T>(
-    node: Element | DocumentFragment, template: (a: T | undefined) => void,
-    data?: T | undefined) => Node|null = createPatchOuter();
+const patchInner: < T > (
+	node: Element | DocumentFragment,
+	template: (a: T | undefined) => void,
+	data ? : T | undefined) => Node = createPatchInner();
+const patchOuter: < T > (
+	node: Element | DocumentFragment, template: (a: T | undefined) => void,
+	data ? : T | undefined) => Node | null = createPatchOuter();
 
 export {
   alignWithDOM,

--- a/src/core.ts
+++ b/src/core.ts
@@ -466,11 +466,11 @@ function createPatchOuter<T>(
 }
 
 const patchInner: <T>(
-    node: Element|DocumentFragment, template: (a: T|undefined) => void,
-    data?: T|undefined) => Node = createPatchInner();
+    node: Element | DocumentFragment, template: (a: T | undefined) => void,
+    data?: T | undefined) => Node = createPatchInner();
 const patchOuter: <T>(
-    node: Element|DocumentFragment, template: (a: T|undefined) => void,
-    data?: T|undefined) => Node|null = createPatchOuter();
+    node: Element | DocumentFragment, template: (a: T | undefined) => void,
+    data?: T | undefined) => Node|null = createPatchOuter();
 
 export {
   alignWithDOM,

--- a/src/core.ts
+++ b/src/core.ts
@@ -465,13 +465,16 @@ function createPatchOuter<T>(
   }, patchConfig);
 }
 
-const patchInner: <T> (
-        node: Element | DocumentFragment,
-        template: (a: T | undefined) => void,
-        data? : T | undefined) => Node = createPatchInner();
-const patchOuter: <T> (
-        node: Element | DocumentFragment, template: (a: T | undefined) => void,
-        data? : T | undefined) => Node | null = createPatchOuter();
+const patchInner: <T>(
+  node: Element | DocumentFragment,
+  template: (a: T | undefined) => void,
+  data?: T | undefined
+) => Node = createPatchInner();
+const patchOuter: <T>(
+  node: Element | DocumentFragment,
+  template: (a: T | undefined) => void,
+  data?: T | undefined
+) => Node | null = createPatchOuter();
 
 export {
   alignWithDOM,


### PR DESCRIPTION
It turns out that the previous typing causes breakages in youtube, so duplicating the type + generics.