### PR TITLE
Use `npm ci` to install dependencies.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - checkout
       - restore_cache:
           key: *cache_key
-      - run: npm install
+      - run: npm ci
       - *save_cache
 
   build:


### PR DESCRIPTION
- This avoids package-lock.json from updating during the install,
causing the checksum to change when saving the cache.