### PR TITLE
Add a publish target.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "bazel test test:unit_tests",
     "build": "bazel build :dev",
     "dist": "npm run lint && npm run test && bazel build :npm",
+    "publish": "npm run dist && bazel run :npm.publish",
     "update": "npm-check -u",
     "lint": "eslint src/**.ts"
   },


### PR DESCRIPTION
Add an explicit target for publishing, since it can be hard to find from
the bazel documentation.