### PR TITLE
Ban setting special attributes

### DIFF
--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -139,6 +139,11 @@ function applyAttributeTyped(el: Element, name: string, value: unknown) {
   }
 }
 
+/** Throws an exception for setting forbidden attributes. */
+function applyForbiddenAttribute(el: Element, name: string, value: unknown) {
+  throw new Error("Invalid attribute " + name + ".");
+}
+
 /**
  * A publicly mutable object to provide custom mutators for attributes.
  * NB: The result of createMap() has to be recast since closure compiler
@@ -152,6 +157,12 @@ const attributes: AttrMutatorConfig = createMap() as AttrMutatorConfig;
 attributes[symbols.default] = applyAttributeTyped;
 
 attributes["style"] = applyStyle;
+
+attributes["innerHTML"] = applyForbiddenAttribute;
+attributes["innerText"] = applyForbiddenAttribute;
+attributes["outerHTML"] = applyForbiddenAttribute;
+attributes["text"] = applyForbiddenAttribute;
+attributes["textContent"] = applyForbiddenAttribute;
 
 /**
  * Calls the appropriate attribute mutator for this attribute.

--- a/test/functional/attributes_spec.ts
+++ b/test/functional/attributes_spec.ts
@@ -290,6 +290,16 @@ describe('attribute updates', () => {
     });
   });
 
+  describe('for forbidden attributes', () => {
+    function render() {
+      elementVoid('div', null, null, 'innerHTML', 'x');
+    }
+    
+    it('should ban innerHTML', () => {
+      expect(() => patch(container, render)).to.throw('Invalid attribute innerHTML.');
+    });
+  });
+
   describe('for non-Incremental DOM attributes', () => {
     function render() {
       elementVoid('div');


### PR DESCRIPTION
This prevents circumventing our checks by code like `<script text="{$evil}">` or `<i innerHTML="{$evil}">` in Soy IDOM.

The newly added test is flaky. Any idea why?