### PR TITLE
Set the nonce attribute before the node is appended to DOM.

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -221,13 +221,16 @@ function nextNode() {
  * @param key The key used to identify the Node.
  * @return The newly created node.
  */
-function createNode(nameOrCtor: NameOrCtorDef, key: Key): Node {
+function createNode(nameOrCtor: NameOrCtorDef, key: Key, nonce?: string): Node {
   let node;
 
   if (nameOrCtor === "#text") {
     node = createText(doc!);
   } else {
     node = createElement(doc!, currentParent!, nameOrCtor, key);
+    if (nonce) {
+      node.setAttribute('nonce', nonce);
+    }
   }
 
   context!.markCreated(node);
@@ -241,10 +244,10 @@ function createNode(nameOrCtor: NameOrCtorDef, key: Key): Node {
  * @param nameOrCtor The name or constructor for the Node.
  * @param key The key used to identify the Node.
  */
-function alignWithDOM(nameOrCtor: NameOrCtorDef, key: Key) {
+function alignWithDOM(nameOrCtor: NameOrCtorDef, key: Key, nonce?: string) {
   nextNode();
   const existingNode = getMatchingNode(currentNode, nameOrCtor, key);
-  const node = existingNode || createNode(nameOrCtor, key);
+  const node = existingNode || createNode(nameOrCtor, key, nonce);
 
   // If we are at the matching node, then we are done.
   if (node === currentNode) {
@@ -274,8 +277,9 @@ function alignWithDOM(nameOrCtor: NameOrCtorDef, key: Key) {
  *     when iterating over an array of items.
  * @return The corresponding Element.
  */
-function open(nameOrCtor: NameOrCtorDef, key?: Key): HTMLElement {
-  alignWithDOM(nameOrCtor, key);
+function open(
+    nameOrCtor: NameOrCtorDef, key?: Key, nonce?: string): HTMLElement {
+  alignWithDOM(nameOrCtor, key, nonce);
   enterNode();
   return currentParent as HTMLElement;
 }

--- a/src/virtual_elements.ts
+++ b/src/virtual_elements.ts
@@ -202,7 +202,8 @@ function elementOpenEnd(): HTMLElement {
     setInAttributes(false);
   }
 
-  const node = open(<NameOrCtorDef>argsBuilder[0], <Key>argsBuilder[1]);
+  const node =
+      open(<NameOrCtorDef>argsBuilder[0], <Key>argsBuilder[1], getNonce());
   const data = getData(node);
 
   diffStatics(node, data, <Statics>argsBuilder[2], attributes);
@@ -210,6 +211,20 @@ function elementOpenEnd(): HTMLElement {
   truncateArray(argsBuilder, 0);
 
   return node;
+}
+
+/** Gets the value of the nonce attribute. */
+function getNonce(): string {
+  const argsBuilder = getArgsBuilder();
+  const statics = <Statics>argsBuilder[2];
+  if (statics) {
+    for (let i = 0; i < statics.length; i += 2) {
+      if (statics[i] === 'nonce') {
+        return statics[i + 1] as string;
+      }
+    }
+  }
+  return '';
 }
 
 /**


### PR DESCRIPTION
If the node is appended to the DOM before the nonce is set then Chrome exclaims with something like: “Refused to apply inline style because it violates the following Content Security Policy directive”.