### PR TITLE
Only call assertPatchOuterHasParentNode() if the node has a key

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -465,7 +465,9 @@ function createPatchOuter<T>(
     fn(data);
 
     if (DEBUG) {
-      assertPatchOuterHasParentNode(currentParent);
+      if (getData(node).key) {
+        assertPatchOuterHasParentNode(currentParent);
+      }
       assertPatchElementNoExtras(
         startNode,
         currentNode,


### PR DESCRIPTION
This fixes false positives that produce warning spam.

This is especially annoying for attributes templates, which can be stringified via patchOuter().

I believe this is the correct check.