### PR TITLE
Fix unit tests on macOS.

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -26,4 +26,5 @@ karma_web_test(
         "@npm//sinon:sinon__umd",
         ":test_lib",
     ],
+    config_file = "karma.conf.js",
 )

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,0 +1,17 @@
+module.exports = function(config) {
+  // Karma tests fail with a Chrome sandbox error on macOS, so disable the
+  // sandbox.
+  if (process.platform === 'darwin') {
+    config.set({
+      browsers: ['ChromeHeadless_macos_fixed'],
+      customLaunchers: {
+        ChromeHeadless_macos_fixed: {
+          base: 'ChromeHeadless',
+          flags: [
+            '--no-sandbox',
+          ],
+        },
+      },
+    });
+  }
+};


### PR DESCRIPTION
This disables Chrome's sandbox when the test in run on macOS.

It's unclear why this is necessary, but it does fix the test. https://gist.github.com/mattem/f6e85437b0dbcca661013a19247889a9#file-karma-conf-js-L49 does something similar. The error in Chrome's logs is "SeatbeltExecServer: Failed to initialize sandbox: -1 Operation not permitted". I couldn't get any more details about the failure or find any details about it online. I don't think sandboxing should matter for these tests though, since it's a security feature.