### PR TITLE
Emit ESM bundle

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,7 +4,7 @@ load("@npm//@bazel/typescript:index.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("@npm//@bazel/rollup:index.bzl", "rollup_bundle")
 
-### Produce umd and cjs bundles
+### Produce umd, cjs and esm bundles
 
 ts_library(
     name = "dev",
@@ -28,6 +28,7 @@ ts_library(
     )
     for format, args in {
         "cjs": [],
+        "esm": [],
         "umd": [
             # Downlevel (transpile) to ES5.
             "-p",
@@ -64,6 +65,23 @@ pkg_npm(
     },
     deps = [
         ":incremental-dom-cjs",
+    ],
+)
+
+genrule(
+    name = "incremental-dom-esm",
+    srcs = [":bundle.esm.js"],
+    outs = ["dist/incremental-dom-esm.js"],
+    cmd = "cp $(locations :bundle.esm.js) $@",
+)
+
+pkg_npm(
+    name = "npm-esm",
+    substitutions = {
+        "const DEBUG = true;": "const DEBUG = false;",
+    },
+    deps = [
+        ":incremental-dom-esm",
     ],
 )
 
@@ -131,6 +149,7 @@ pkg_npm(
     ],
     nested_packages = [
         ":npm-cjs",
+        ":npm-esm",
         ":npm-min",
         ":npm-umd",
     ],

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "incremental-dom",
   "version": "0.7.0",
   "description": "An in-place virtual DOM library",
+  "exports": "dist/incremental-dom-esm.js",
   "main": "dist/incremental-dom-cjs.js",
   "author": "The Incremental DOM Authors",
   "license": "Apache-2.0",


### PR DESCRIPTION
Hello and thank You for this project and Your efforts! :rocket:

This small pull request just adds an ESM flavoured bundle to the build outputs without touching any logic. This ESM bundle may then be consumed by the browser directly via:
- [cdnjs](https://cdnjs.com/libraries/incremental-dom)
- [jsdelivr](https://cdn.jsdelivr.net/npm/incremental-dom/)
- [unpkg](https://unpkg.com/browse/incremental-dom/)
- etc.

If You have any suggestions or comments, please let me know!