### PR TITLE
Pierce ShadowRoot boundary when getting ancestry

### DIFF
--- a/src/dom_util.ts
+++ b/src/dom_util.ts
@@ -44,7 +44,9 @@ function getAncestry(node: Node, root: Node | null) {
   while (cur !== root) {
     const n: Node = assert(cur);
     ancestry.push(n);
-    cur = n.parentNode;
+    // If `node` is inside of a ShadowRoot, then it needs to pierce the
+    // ShadowRoot boundary in order to reach `root`.
+    cur = n.parentNode || (n as ShadowRoot)?.host;
   }
 
   return ancestry;

--- a/src/dom_util.ts
+++ b/src/dom_util.ts
@@ -46,7 +46,7 @@ function getAncestry(node: Node, root: Node | null) {
     ancestry.push(n);
     // If `node` is inside of a ShadowRoot, then it needs to pierce the
     // ShadowRoot boundary in order to reach `root`.
-    cur = n.parentNode || (n as ShadowRoot)?.host;
+    cur = n.parentNode || (n as ShadowRoot).host;
   }
 
   return ancestry;


### PR DESCRIPTION
With on-demand ShadyDOM, the DOM is rendered without shadow roots, but the API acts as if these shadow nodes exist. This can cause issues with getFocusedPath calls where the activeElement is inside of a shadow DOM, thus getting the ancestry of the activeElement to the root results in an assertion error because `n.parentNode` returns undefined. We can get around this by piercing through the shadow DOM boundary.

This should only affect on-demand ShadyDOM since for regular ShadowDOM, the `!node.contains(activeElement)` check would be true causing getFocusedPath to short circuit.