### PR TITLE
Fix getAncestry handling with null root

### DIFF
--- a/src/dom_util.ts
+++ b/src/dom_util.ts
@@ -46,7 +46,7 @@ function getAncestry(node: Node, root: Node | null) {
     ancestry.push(n);
     // If `node` is inside of a ShadowRoot, then it needs to pierce the
     // ShadowRoot boundary in order to reach `root`.
-    cur = n.parentNode || (n as ShadowRoot).host;
+    cur = n.parentNode || (root ? (n as ShadowRoot).host : null);
   }
 
   return ancestry;


### PR DESCRIPTION
There was a missed test failure from merging #486 around patching a ShadowRoot.

In the case that the root is null, getAncestry shouldn't pierce through the shadow DOM. This only happens when `node.parentNode` is null, which only happens when the node is a document fragment or ShadowRoot.