### PR TITLE
Don't use localName to identify tags, if it's not populated

### DIFF
--- a/src/node_data.ts
+++ b/src/node_data.ts
@@ -135,7 +135,9 @@ function importSingleNode(node: Node, fallbackKey?: Key): NodeData {
     return node["__incrementalDOMData"];
   }
 
-  const nodeName = isElement(node) ? node.localName : node.nodeName;
+  // Cobalt 9 doesn't populate localName.
+  const nodeName =
+      isElement(node) && node.localName ? node.localName : node.nodeName;
   const keyAttrName = getKeyAttributeName();
   const keyAttr =
     isElement(node) && keyAttrName != null

--- a/src/node_data.ts
+++ b/src/node_data.ts
@@ -135,9 +135,9 @@ function importSingleNode(node: Node, fallbackKey?: Key): NodeData {
     return node["__incrementalDOMData"];
   }
 
-  // Cobalt 9 doesn't populate localName.
-  const nodeName =
-      isElement(node) && node.localName ? node.localName : node.nodeName;
+  // localName is preferred, but it's only available on Element, and some
+  // browsers (e.g. Cobalt 9) don't populate it anyway.
+  const nodeName = (node as Element).localName ?? node.nodeName;
   const keyAttrName = getKeyAttributeName();
   const keyAttr =
     isElement(node) && keyAttrName != null


### PR DESCRIPTION
Don't use `localName` to identify tags, if it's not populated.

In browsers that don't populate `localName`, idom couldn't identify the tag name during patch, and would always think that a different tag was being re-rendered, always recreating DOM nodes rather than reusing them (you can't change the tag name of an existing node).

I verified this issue on Cobalt 9, but this may also affect IE <=8 and other old browsers. https://caniuse.com/?search=localName

Quick links:
* `Element.localName` https://developer.mozilla.org/en-US/docs/Web/API/Element/localName
* `Node.nodeName` https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeName
* `Element.tagName` https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName